### PR TITLE
t-target-api: Fix testcase when there is only 1 or 2 devices

### DIFF
--- a/t-target-api/test.c
+++ b/t-target-api/test.c
@@ -34,13 +34,14 @@ int main(void){
   printf("Default device outside task: %d\n", omp_get_default_device());
 
   // default device can set to whatever, if target fails, it goes to the host
-  const int default_device = 3;
+  const int default_device = (omp_get_num_devices() >= 3
+                              ? 3 : omp_get_num_devices() >= 2 ? 2 : 1);
   omp_set_default_device(default_device);
 
   // default device for omp target call MUST be >= 0 and <omp_get_num_devices() or
-  // the initial device. So when there are no devices, it must be the initial device
+  // the initial device. So when there to few devices, it must be the initial device
   int default_device_omp_target_call = default_device;
-  if (omp_get_num_devices() == 0) {
+  if (default_device > omp_get_num_devices()) {
     default_device_omp_target_call = omp_get_initial_device();
   } 
   #if DEBUG


### PR DESCRIPTION
The code sets the _default-device-var_ ICV to 3 – assuming that host fallback is done; well, that's the case for the **target** regions but not for **omp_target_alloc** - as that requires a conforming device number.

The solution is to call **omp_target_alloc** for the host if _default-device-var_ is too large, i.e. instead of checking for no device, the check is now whether the default device is larger than the number of devices.

While that fixes the issue, I guess it is more useful to actually use a device - if there is one or two available - which is the second change.

To check on the host, one way out is still to set
`OMP_TARGET_OFFLOAD=DISABLED`, which is the supposed way in omptests; cf. [utilities/check.h
](https://github.com/doru1004/omptests/blob/main/utilities/check.h)
@doru1004 – What you do think?