### PR TITLE
nt-struct1: Add pointer cast of malloc result for C++

### DIFF
--- a/nt-struct1/test.c
+++ b/nt-struct1/test.c
@@ -25,7 +25,7 @@ void print(S *s)
   printf("  x %5.3f, y %5.3f, z %5.3f\n", s->x,  s->y, s->z);
 }
 
-#define ALLOC_STRUCT(s) { s.pC = malloc(N*sizeof(double)); }
+#define ALLOC_STRUCT(s) { s.pC = (double*) malloc(N*sizeof(double)); }
 #define FREE_STRUCT(s) { free(s.pC); }
 
 #define INIT_STRUCT(s) { \


### PR DESCRIPTION
While the C compiler 'gcc' happily accepts this code, the C++ one, g++, doesn't like it and complains:
`error: invalid conversion from 'void*' to 'double*'`

Hence, apply the obvious fix.

@doru1004 – what do you think?