### PR TITLE
xt-declare-target-ctors: Update for GCC

### DIFF
--- a/xt-declare-target-ctors/expected
+++ b/xt-declare-target-ctors/expected
@@ -10,6 +10,12 @@ CtorD: 123 Device
 CtorD: 123 Device
 CtorD: 123 Device
 Main: 123 Device
+DtorE: 1860867 Device
+DtorD: 1860867 Device
+DtorD: 1860867 Device
+DtorD: 1860867 Device
+DtorC: 123 Device
+DtorA: 5159780352 Device
 DtorW: 56 Host
 DtorE: 1860867 Host
 DtorD: 1860867 Host
@@ -17,9 +23,3 @@ DtorD: 1860867 Host
 DtorD: 1860867 Host
 DtorC: 123 Host
 DtorA: 5159780352 Host
-DtorA: 5159780352 Device
-DtorC: 123 Device
-DtorD: 1860867 Device
-DtorD: 1860867 Device
-DtorD: 1860867 Device
-DtorE: 1860867 Device

--- a/xt-declare-target-ctors/test.cpp
+++ b/xt-declare-target-ctors/test.cpp
@@ -22,16 +22,14 @@ struct NoOffloadCtorDtor {
   
     if (!offloading_disabled() || !RunDtor)
       return;
-    printf("DtorA: 5159780352 Device\n");
-    printf("DtorC: 123 Device\n");
-    printf("DtorD: 1860867 Device\n");
-    printf("DtorD: 1860867 Device\n");
-    printf("DtorD: 1860867 Device\n");
     printf("DtorE: 1860867 Device\n");
+    printf("DtorD: 1860867 Device\n");
+    printf("DtorD: 1860867 Device\n");
+    printf("DtorD: 1860867 Device\n");
+    printf("DtorC: 123 Device\n");
+    printf("DtorA: 5159780352 Device\n");
   }
 };
-
-NoOffloadCtorDtor NC0(true);
 
 #pragma omp declare target
 
@@ -107,11 +105,11 @@ SSE se;
 
 SSW sw(56);
 
-NoOffloadCtorDtor NC1(false);
-
 int main(void) {
 
   bool OffloadDisabled = offloading_disabled();
+
+  NoOffloadCtorDtor NC0(false);
 
   #pragma omp target device(0)
   #pragma omp teams num_teams(1) thread_limit(1)
@@ -119,5 +117,8 @@ int main(void) {
   {
    printf("Main: %d %s\n",123, (omp_is_initial_device() && !OffloadDisabled) ? "Host" : "Device");
   }
+
+  NoOffloadCtorDtor NC1(true);
+
   return 0;
 }


### PR DESCRIPTION
It's not clear from the revision log what compiler the xt-declare-target-ctors test has been written against, in particular, its
'xt-declare-target-ctors/expected' file.  But it must've been a long time ago.

Updating this for current GCC:

 1. Like on the host, also for offloading: destructors run in reverse order of constructors.
 2. Offloading is initialized (and with that, offloading constructors are run) upon encountering the first offloading construct (here: '#pragma omp target'), and offloading is shut down (and with that, offloading destructors are run) at the end of 'main', before destructing host objects.