### PR TITLE
t-taskloop: fix missing lastprivate clause

### DIFF
--- a/t-taskloop/test.c
+++ b/t-taskloop/test.c
@@ -176,7 +176,7 @@ int main()
     {
 #pragma omp parallel
 #pragma omp single
-#pragma omp taskloop shared(a) lastprivate(myId)
+#pragma omp taskloop shared(a) lastprivate(lp)
       for(int i = 0 ; i < N; i++) {
 	a[i] += b[i] + c[i];
 	lp = a[i];

--- a/t-taskloopsimd/test.c
+++ b/t-taskloopsimd/test.c
@@ -178,7 +178,7 @@ int main()
     {
 #pragma omp parallel
 #pragma omp single
-#pragma omp taskloop simd shared(a) lastprivate(myId)
+#pragma omp taskloop simd shared(a) lastprivate(lp)
       for(int i = 0 ; i < N; i++) {
 	a[i] += b[i] + c[i];
 	lp = a[i];


### PR DESCRIPTION
Cc @tob2

this test was intermittently failing due to the `lastprivate` clause modified in the patch pointing to the wrong variable.