### PR TITLE
Fix t-target-api + t-unified-target-api

### DIFF
--- a/t-target-api/test.c
+++ b/t-target-api/test.c
@@ -34,15 +34,14 @@ int main(void){
   printf("Default device outside task: %d\n", omp_get_default_device());
 
   // default device can set to whatever, if target fails, it goes to the host
-  const int default_device = (omp_get_num_devices() >= 3
-                              ? 3 : omp_get_num_devices() >= 2 ? 2 : 1);
+  const int default_device = 3;
   omp_set_default_device(default_device);
 
   // default device for omp target call MUST be >= 0 and <omp_get_num_devices() or
-  // the initial device. So when there to few devices, it must be the initial device
+  // the initial device; use 0 which is the first offload device, if any, else the host.
   int default_device_omp_target_call = default_device;
-  if (default_device > omp_get_num_devices()) {
-    default_device_omp_target_call = omp_get_initial_device();
+  if (default_device >= omp_get_num_devices()) {
+    default_device_omp_target_call = 0;
   } 
   #if DEBUG
     printf("test on machine with %d devices\n", omp_get_num_devices());
@@ -78,7 +77,7 @@ int main(void){
   omp_target_memcpy(dpD, pD, N*sizeof(double), 300*sizeof(double),
       30*sizeof(double), default_device_omp_target_call, omp_get_initial_device());
 
-  #pragma omp target is_device_ptr(dpA, dpC, dpD) device(default_device)
+  #pragma omp target is_device_ptr(dpA, dpC, dpD) device(default_device_omp_target_call)
   {
     #pragma omp parallel for schedule(static,1)
     for (int i = 0; i < 992; i++)

--- a/t-unified-target-api/test.c
+++ b/t-unified-target-api/test.c
@@ -40,10 +40,10 @@ int main(void){
   omp_set_default_device(default_device);
 
   // default device for omp target call MUST be >= 0 and <omp_get_num_devices() or
-  // the initial device. So when there are no devices, it must be the initial device
+  // the initial device; use 0 which is the first offload device, if any, else the host.
   int default_device_omp_target_call = default_device;
-  if (omp_get_num_devices() == 0) {
-    default_device_omp_target_call = omp_get_initial_device();
+  if (default_device >= omp_get_num_devices()) {
+    default_device_omp_target_call = 0;
   } 
   #if DEBUG
     printf("test on machine with %d devices\n", omp_get_num_devices());
@@ -78,7 +78,7 @@ int main(void){
   omp_target_memcpy(dpD, pD, N*sizeof(double), 300*sizeof(double),
       30*sizeof(double), default_device_omp_target_call, omp_get_initial_device());
 
-  #pragma omp target is_device_ptr(dpA, dpC, dpD) device(default_device)
+  #pragma omp target is_device_ptr(dpA, dpC, dpD) device(default_device_omp_target_call)
   {
     #pragma omp parallel for schedule(static,1)
     for (int i = 0; i < 992; i++) {


### PR DESCRIPTION
Seems as if previous fixes were not sufficient. This patch changes:
* Partially revert to previous version for t-target-api, which matches t-unified-target-api. Instead, use 0 (unless there are > 3 devices) as device, which is the first offload device, unless there is only the initial device - which is then used instead.
* The omp_target_alloc and omp_target_memcpy should use the same device as the target region – otherwise, the latter uses the device pointer for the wrong device.

@doru1004 – please have a look. — _It seems as if I partially screwed up when trying to fix t-target-api before – and I also missed t-unified-target-api. Before t-target-api worked if USM was available but not enabled, which was a slightly odd side effect._