### PR TITLE
Fix nt-target-map-ptr

### DIFF
--- a/nt-target-map-ptr/expected
+++ b/nt-target-map-ptr/expected
@@ -1,3 +1,6 @@
 Able to use offloading!
 Test full extent: Succeeded
+Test full extent with zero length ptrs: Succeeded
+Test full extent struct: Succeeded
 Test3: Succeeded
+Test full extent struct: Succeeded

--- a/nt-target-map-ptr/test.c
+++ b/nt-target-map-ptr/test.c
@@ -6,11 +6,11 @@
 #include "../utilities/utilities.h"
 
 // enable tests
-#define FULL      0
+#define FULL      1
 #define FULL_ZERO 1  /* use zero ptrs */
-#define FULL_S    0  /* need struct support */
-#define OFFSET    0 
-#define OFFSET_S  0  /* need struct support */
+#define FULL_S    1  /* need struct support */
+#define OFFSET    1
+#define OFFSET_S  1  /* need struct support */
 
 #define N (992)
 
@@ -22,14 +22,18 @@ typedef struct S {
 } S;
 
 int main(void){
-  #if FULL !=0 && FULL_ZERO != 0 && FULL_S != 0 && OFFSET != 0 && OFFSET_S != 0
+  #if FULL !=0 || FULL_ZERO != 0 || FULL_S != 0 || OFFSET != 0 || OFFSET_S != 0
     check_offloading();
   #endif
 
-  int fail;
+  int fail, any_fail = 0;
   double A[N], B[N], C[N], D[N], E[N];
   double *pA, *pB, *pC, *pD, *pE;
   S s1;
+  int dev_num;
+
+  /* The code below assumes that an offload device is available. */
+  dev_num = omp_get_num_devices() >= 2 ? 1 : 0;
 
   // map ptrs
   pA = &A[0];
@@ -49,7 +53,7 @@ int main(void){
   // Test: Execute on device (full extend)
   //
   INIT();
-  #pragma omp target device(1) map(from: pA[0:N]) map(to: pC[0:N]) map(pD[0:N]) 
+  #pragma omp target device(dev_num) map(from: pA[0:N]) map(to: pC[0:N]) map(pD[0:N])
   {
     #pragma omp parallel for schedule(static,1)
     for (int i = 0; i < 992; i++)
@@ -63,6 +67,7 @@ int main(void){
   } else {
     printf ("Test full extent: Succeeded\n");
   }
+  any_fail += fail;
 #endif
 
 #if FULL_ZERO
@@ -70,9 +75,9 @@ int main(void){
   // Test: Execute on device (full extend)
   //
   INIT();
-  #pragma omp target data map(from: pA[0:N]) map(to: pC[0:N]) map(pD[0:N]) device(1) 
+  #pragma omp target data map(from: pA[0:N]) map(to: pC[0:N]) map(pD[0:N]) device(dev_num)
   {
-    #pragma omp target device(1) // implicit zero ptr
+    #pragma omp target device(dev_num) // implicit zero ptr
     {
       #pragma omp parallel for schedule(static,1) 
       for (int i = 0; i < 992; i++)
@@ -87,6 +92,7 @@ int main(void){
   } else {
     printf ("Test full extent with zero length ptrs: Succeeded\n");
   }
+  any_fail += fail;
 #endif
 
 #if FULL_S
@@ -94,7 +100,7 @@ int main(void){
   // Test: Execute on device (full extend
   //
   INIT();
-  #pragma omp target device(1) map(s1) map(from: s1.pA[0:N])  map(to: s1.pC[0:N]) map(s1.pD[0:N])
+  #pragma omp target device(dev_num) map(s1) map(from: s1.pA[0:N])  map(to: s1.pC[0:N]) map(s1.pD[0:N])
   {
     #pragma omp parallel for schedule(static,1)
     for (int i = 0; i < 992; i++)
@@ -108,6 +114,7 @@ int main(void){
   } else {
     printf ("Test full extent struct: Succeeded\n");
   }
+  any_fail += fail;
 #endif
 
 #if OFFSET
@@ -118,11 +125,11 @@ int main(void){
   pC = pC - 200;
   pD = pD - 300;
   INIT();
-  #pragma omp target device(1) map(from: pA[100:N]) map(to: pC[200:N]) map(pD[300:N]) 
+  #pragma omp target device(dev_num) map(from: pA[100:N]) map(to: pC[200:N]) map(pD[300:N])
   {
     #pragma omp parallel for schedule(static,1)
     for (int i = 0; i < 992; i++)
-      pA[i] = pC[i] + pD[i] + omp_is_initial_device();
+      pA[i+100] = pC[i+200] + pD[i+300] + omp_is_initial_device();
   }
   // CHECK: Succeeded
   fail = 0;
@@ -132,6 +139,7 @@ int main(void){
   } else {
     printf ("Test3: Succeeded\n");
   }
+  any_fail += fail;
 #endif
 
 #if OFFSET_S
@@ -142,11 +150,11 @@ int main(void){
   s1.pC = s1.pC - 200;
   s1.pD = s1.pD - 300;
   INIT();
-  #pragma omp target device(1) map(s1) map(from: s1.pA[100:N])  map(to: s1.pC[200:N]) map(s1.pD[300:N])
+  #pragma omp target device(dev_num) map(s1) map(from: s1.pA[100:N])  map(to: s1.pC[200:N]) map(s1.pD[300:N])
   {
     #pragma omp parallel for schedule(static,1)
     for (int i = 0; i < 992; i++)
-      s1.pA[i] = s1.pC[i] + s1.pD[i] + omp_is_initial_device();
+      s1.pA[i+100] = s1.pC[i+200] + s1.pD[i+300] + omp_is_initial_device();
   }
   // CHECK: Succeeded
   fail = 0;
@@ -156,7 +164,8 @@ int main(void){
   } else {
     printf ("Test full extent struct: Succeeded\n");
   }
+  any_fail += fail;
 #endif
 
-  return 0;
+  return any_fail > 0 ? 1 : 0;
 }


### PR DESCRIPTION
The current code assumed that there are >= 2 offload devices are available, failing if there is only a single one. Additionally fixes:
* Run check_offloading() also if only some tests are enabled.
* Return != 0 if any test failed
* Fixed offset tests
* Enable all tests - and update expected output.

@doru1004 – looked by chance at the fail – and found several issues. Please consider merging.