### PR TITLE
On error, return nonzero exit status; fix some pragmas

### DIFF
--- a/t-barrier/test.c
+++ b/t-barrier/test.c
@@ -102,6 +102,7 @@ int main(void) {
   check_offloading();
 
   double A[N+2], B[N+2], C[N+2], D[N+2], E[N+2];
+  int any_fail = 0;
 
   INIT();
 
@@ -119,7 +120,7 @@ int main(void) {
   //
   TESTD("omp target teams num_teams(1) thread_limit(32)", {
     PARALLEL_A()
-  }, VERIFY(0, 1, B[i], i+1));
+  }, {VERIFY(0, 1, B[i], i+1); any_fail += fail;});
 
   //
   // Test: Barrier in a parallel region.
@@ -129,7 +130,7 @@ int main(void) {
     TESTD("omp target teams num_teams(1) thread_limit(max_threads)", {
     ZERO(B);
     PARALLEL_B5()
-    }, VERIFY(0, threads[0]-1, B[i], 5));
+    }, {VERIFY(0, threads[0]-1, B[i], 5); any_fail += fail;});
   }
   DUMP_SUCCESS(gpu_threads-max_threads);
 
@@ -142,15 +143,15 @@ int main(void) {
     int threads[1]; threads[0] = t;
     PARALLEL_B()
   }
-  }, VERIFY(0, max_threads-1, B[i], (max_threads / 32) - (i+1) / 32));
+  }, {VERIFY(0, max_threads-1, B[i], (max_threads / 32) - (i+1) / 32); any_fail += fail;});
 
   //
   // Test: Single thread in target region.
   //
-  TESTD("#pragma omp target", {
+  TESTD("omp target", {
   ZERO(B);
   BODY_B()
-  }, VERIFY(0, 1, C[i], 491535));
+  }, {VERIFY(0, 1, C[i], 491535); any_fail += fail;});
 
   //
   // Test: Barrier in target parallel.
@@ -160,7 +161,7 @@ int main(void) {
     int threads; threads = t;
     TESTD("omp target parallel num_threads(threads)", {
       BODY_B();
-    }, VERIFY(0, t-1, B[i], (trial+1)*1.0));
+    }, {VERIFY(0, t-1, B[i], (trial+1)*1.0); any_fail += fail;});
   }
   DUMP_SUCCESS(gpu_threads-max_threads);
 
@@ -172,7 +173,7 @@ int main(void) {
     ZERO(B);
     TEST({
       BODY_NP();
-    }, VERIFY(0, 16*16, B[i], (i > 0 && (i+1) % 16 == 0 ? 0 : (trial+1)*1)) );
+    }, {VERIFY(0, 16*16, B[i], (i > 0 && (i+1) % 16 == 0 ? 0 : (trial+1)*1)); any_fail += fail;} );
   } else {
     DUMP_SUCCESS(1);
   }
@@ -183,4 +184,5 @@ int main(void) {
   // target + simd
   // target/teams/parallel with varying numbers of threads
 
+  return any_fail > 0;
 }

--- a/t-multiple-parallel/test.c
+++ b/t-multiple-parallel/test.c
@@ -29,6 +29,8 @@
 #define PARALLEL125() { PARALLEL25() PARALLEL25() PARALLEL25() PARALLEL25() PARALLEL25() }
 
 int main(void) {
+  int any_fail = 0;
+
   check_offloading();
 
   double A[N], B[N], C[N], D[N], E[N];
@@ -43,7 +45,7 @@ int main(void) {
      A[i] = 0;
    }
    PARALLEL125()
-  }, VERIFY(0, 512, A[i], 125*(1+i)));
+  }, {VERIFY(0, 512, A[i], 125*(1+i)); any_fail += fail;});
 
-  return 0;
+  return any_fail > 0;
 }

--- a/t-parallel/test.c
+++ b/t-parallel/test.c
@@ -14,6 +14,7 @@
 #define ZERO(X) ZERO_ARRAY(N, X)
 
 int main(void) {
+  int any_fail = 0;
   check_offloading();
 
   double A[N], B[N], C[N], D[N], E[N];
@@ -38,7 +39,7 @@ int main(void) {
       int tid = omp_get_thread_num();
       A[tid] += tid;
     }
-  }, VERIFY(0, 128, A[i], i*(trial+1)));
+  }, {VERIFY(0, 128, A[i], i*(trial+1)); any_fail += fail;});
 
   //
   // Test: Execute parallel on device
@@ -51,7 +52,7 @@ int main(void) {
         B[j] = D[j] + E[j];
       }
     }
-    }, VERIFY(0, 512, B[i], (double)0));
+    }, {VERIFY(0, 512, B[i], (double)0); any_fail += fail;});
 
   //
   // Test: if clause serial execution of parallel region on target
@@ -63,7 +64,7 @@ int main(void) {
       int tid = omp_get_thread_num();
       A[tid] = tid;
     }
-  }, VERIFY(0, 128, A[i], 0));
+  }, {VERIFY(0, 128, A[i], 0); any_fail += fail;});
 
   //
   // Test: if clause serial execution of parallel region on target
@@ -75,7 +76,7 @@ int main(void) {
       int tid = omp_get_thread_num();
       A[tid] = tid;
     }
-  }, VERIFY(0, 128, A[i], 0));
+  }, {VERIFY(0, 128, A[i], 0); any_fail += fail;});
 
   //
   // Test: if clause parallel execution of parallel region on target
@@ -87,7 +88,7 @@ int main(void) {
       int tid = omp_get_thread_num();
       A[tid] = tid;
     }
-  }, VERIFY(0, 128, A[i], i));
+  }, {VERIFY(0, 128, A[i], i); any_fail += fail;});
 
   //
   // Test: proc_bind clause
@@ -114,7 +115,7 @@ int main(void) {
         B[j] += 1 + D[j] + E[j];
       }
     }
-  }, VERIFY(0, 512, B[i], 3));
+  }, {VERIFY(0, 512, B[i], 3); any_fail += fail;});
 
   //
   // Test: num_threads on parallel.
@@ -132,7 +133,7 @@ int main(void) {
         int tid = omp_get_thread_num();
         A[tid] = 99;
       }
-    }, VERIFY(0, 128, A[i], 99*(i < t)));
+    }, {VERIFY(0, 128, A[i], 99*(i < t)); any_fail += fail;});
   }
 
   //
@@ -150,7 +151,7 @@ int main(void) {
       A[0] += tmp;
     }
   A[0] += tmp;
-  }, VERIFY(0, 1, A[i], 5));
+  }, {VERIFY(0, 1, A[i], 5); any_fail += fail;});
 
   //
   // Test: private clause on parallel region.
@@ -167,7 +168,7 @@ int main(void) {
       A[0] += tmp;
     }
   A[0] += tmp;
-  }, VERIFY(0, 1, A[i], 4));
+  }, {VERIFY(0, 1, A[i], 4); any_fail += fail;});
 
   //
   // Test: firstprivate clause on parallel region.
@@ -184,7 +185,7 @@ int main(void) {
       A[0] += tmp;
     }
   A[0] += tmp;
-  }, VERIFY(0, 1, A[i], 5));
+  }, {VERIFY(0, 1, A[i], 5); any_fail += fail;});
 
   //
   // Test: shared clause on parallel region.
@@ -203,7 +204,7 @@ int main(void) {
       A[0] += tmp;
     }
   A[0] += tmp + distance;
-  }, VERIFY(0, 1, A[i], 65));
+  }, {VERIFY(0, 1, A[i], 65); any_fail += fail;});
 
   //
   // Test: sharing of array from master to parallel region.
@@ -225,7 +226,7 @@ int main(void) {
   for (int i = 0; i < 128; i++) {
     A[i] += B[i];
   }
-  }, VERIFY(0, 128, A[i], 103));
+  }, {VERIFY(0, 128, A[i], 103); any_fail += fail;});
 
   //
   // Test: array private clause on parallel region.
@@ -247,7 +248,7 @@ int main(void) {
   for (int i = 0; i < 128; i++) {
     A[i] += B[i];
   }
-  }, VERIFY(0, 128, A[i], 101));
+  }, {VERIFY(0, 128, A[i], 101); any_fail += fail;});
 
   //
   // Test: array firstprivate clause on parallel region.
@@ -269,7 +270,7 @@ int main(void) {
   for (int i = 0; i < 128; i++) {
     A[i] += B[i];
   }
-  }, VERIFY(0, 128, A[i], 111));
+  }, {VERIFY(0, 128, A[i], 111); any_fail += fail;});
 
   //
   // Test: array shared clause on parallel region.
@@ -291,7 +292,7 @@ int main(void) {
       A[0] += B[0] + distance[30];
     }
   A[0] += B[0] + distance[30];
-  }, VERIFY(0, 1, A[i], 171));
+  }, {VERIFY(0, 1, A[i], 171); any_fail += fail;});
 
   struct CITY {
     char name[128];
@@ -326,7 +327,7 @@ int main(void) {
       int tid = omp_get_thread_num();
       data.A[1+tid] += 1+tid + (int) data.city.name[1] + data.city.distance_to_nyc;
     }
-  }, VERIFY(0, 128, data.A[i], (132 + i)*(trial+1)));
+  }, {VERIFY(0, 128, data.A[i], (132 + i)*(trial+1)); any_fail += fail;});
 
   //
   // Test: sharing of struct from master to parallel region.
@@ -348,7 +349,7 @@ int main(void) {
   for (int i = 0; i < 128; i++) {
     data.A[i] += data.B[i];
   }
-  }, VERIFY(0, 128, data.A[i], 103));
+  }, {VERIFY(0, 128, data.A[i], 103); any_fail += fail;});
 
   //
   // Test: struct private clause on parallel region.
@@ -370,7 +371,7 @@ int main(void) {
   for (int i = 0; i < 128; i++) {
     data.A[i] += data.B[i];
   }
-  }, VERIFY(0, 1, data.A[i], 100));
+  }, {VERIFY(0, 1, data.A[i], 100); any_fail += fail;});
 
   //
   // Test: struct firstprivate clause on parallel region.
@@ -391,7 +392,7 @@ int main(void) {
       tmp = data.A[0];
     }
   data.A[0] += data.B[0] + tmp;
-  }, VERIFY(0, 1, data.A[i], 210));
+  }, {VERIFY(0, 1, data.A[i], 210); any_fail += fail;});
 
   //
   // Test: struct shared clause on parallel region.
@@ -413,7 +414,7 @@ int main(void) {
       A[0] += B[0] + city.distance_to_nyc;
     }
   A[0] += B[0] + city.distance_to_nyc;
-  }, VERIFY(0, 1, A[i], 171));
+  }, {VERIFY(0, 1, A[i], 171); any_fail += fail;});
 
-  return 0;
+  return any_fail > 0;
 }

--- a/t-runtime-calls/test.c
+++ b/t-runtime-calls/test.c
@@ -21,6 +21,7 @@
 //
 
 int main(void) {
+  int any_fail = 0;
   // CHECK: Able to use offloading!
   check_offloading();
 
@@ -41,7 +42,7 @@ int main(void) {
         A[0] += omp_get_num_threads();  // 128
       }
     }
-  }, VERIFY(0, 1, A[i], 129));
+  }, {VERIFY(0, 1, A[i], 129); any_fail += fail;});
 
   //
   // Test: omp_get_max_threads() (depends on device type)
@@ -57,7 +58,7 @@ int main(void) {
 	    A[1] = omp_get_num_threads();
 	  }
       }
-    }, if (!omp_is_initial_device()) VERIFY(0, 1, A[i], A[1] + 1));
+    }, if (!omp_is_initial_device()) {VERIFY(0, 1, A[i], A[1] + 1); any_fail += fail;});
   //
   // Test: omp_get_num_procs()
   //
@@ -72,7 +73,7 @@ int main(void) {
         A[1] = 2*omp_get_num_threads();
       }
     }
-  }, VERIFY(0, 1, A[i], A[1]));
+  }, {VERIFY(0, 1, A[i], A[1]); any_fail += fail;});
   
   //
   // Test: omp_in_parallel()
@@ -81,24 +82,24 @@ int main(void) {
   TEST({
   _Pragma("omp distribute dist_schedule(static,1)")
     for (int i = 0; i < 1; ++i) {
-      _Pragma("atomic write")
+      _Pragma("omp atomic write")
         A[0] = omp_in_parallel();  // 0
     }
    // Serialized parallel
   _Pragma("omp parallel num_threads(32) if (A[0] == 1)")
     {
-      _Pragma("atomic update")
+      _Pragma("omp atomic update")
         A[0] += omp_in_parallel();  // 0
     }
     // Parallel execution
   _Pragma("omp parallel num_threads(32) if (A[0] == 0)")
     {
       if (omp_get_thread_num() == 0) {
-        _Pragma("atomic update")
+        _Pragma("omp atomic update")
           A[0] += omp_in_parallel();  // 1
       }
     }
-  }, VERIFY(0, 1, A[i], 1));
+  }, {VERIFY(0, 1, A[i], 1); any_fail += fail;});
 
   //
   // Test: omp_set/get_dynamic()
@@ -122,7 +123,7 @@ int main(void) {
   _Pragma("omp distribute dist_schedule(static,1)")
   for (int i = 0; i < 1; ++i)
     A[0] += omp_get_dynamic();  // 1
-  }, VERIFY(0, 1, A[i], 3));
+  }, {VERIFY(0, 1, A[i], 3); any_fail += fail;});
 
   //
   // Test: omp_get_cancellation()
@@ -138,7 +139,7 @@ int main(void) {
         A[0] += omp_get_cancellation();  // 0
       }
     }
-  }, VERIFY(0, 1, A[i], 0));
+  }, {VERIFY(0, 1, A[i], 0); any_fail += fail;});
 
   //
   // Test: omp_set/get_nested().  Not used on the device currently.
@@ -160,7 +161,7 @@ int main(void) {
     }
   _Pragma("omp parallel if(0)")
     A[0] += omp_get_nested();  // 0
-  }, VERIFY(0, 1, A[i], 0));
+  }, {VERIFY(0, 1, A[i], 0); any_fail += fail;});
 
   //
   // Test: omp_set/get_schedule().
@@ -216,7 +217,7 @@ int main(void) {
     _Pragma("omp parallel if(0)")
       omp_get_schedule(&t, &chunk_size);  // should read 1, 10;
     A[0] += t + chunk_size;
-  }, VERIFY(0, 1, A[i], result));
+  }, {VERIFY(0, 1, A[i], result); any_fail += fail;});
 
   //
   // Test: omp_get_thread_limit()
@@ -233,7 +234,7 @@ int main(void) {
         A[1] = 2*omp_get_num_threads();
       }
     }
-  }, VERIFY(0, 1, A[i], A[1]));
+  }, {VERIFY(0, 1, A[i], A[1]); any_fail += fail;});
 
   //
   // Test: omp_set/get_max_active_levels()
@@ -252,7 +253,7 @@ int main(void) {
         A[0] += omp_get_max_active_levels();  // 1
       }
     }
-  }, VERIFY(0, 1, A[i], 2));
+  }, {VERIFY(0, 1, A[i], 2); any_fail += fail;});
 
   //
   // Test: omp_get_level()
@@ -268,7 +269,7 @@ int main(void) {
         A[0] += omp_get_level();  // 1
       }
     }
-  }, VERIFY(0, 1, A[i], 1));
+  }, {VERIFY(0, 1, A[i], 1); any_fail += fail;});
 
   //
   // Test: omp_get_ancestor_thread_num()
@@ -283,7 +284,7 @@ int main(void) {
 	  A[0] += omp_get_ancestor_thread_num(0) + omp_get_ancestor_thread_num(1);  // 0 + 18
 	}
       }
-    }, VERIFY(0, 1, A[i], 0));
+    }, {VERIFY(0, 1, A[i], 0); any_fail += fail;});
 
   //
   // Test: omp_get_team_size()
@@ -298,7 +299,7 @@ int main(void) {
         A[0] += omp_get_team_size(0) + omp_get_team_size(1);  // 1 + 19
       }
     }
-    }, if (!omp_is_initial_device()) VERIFY(0, 1, A[i], 22)); // TODO: fix host execution
+    }, if (!omp_is_initial_device()) {VERIFY(0, 1, A[i], 22); any_fail += fail;}); // TODO: fix host execution
   //
   // Test: omp_get_active_level()
   //
@@ -315,7 +316,7 @@ int main(void) {
           A[0] += omp_get_active_level();  // 1
       }
     }
-  }, VERIFY(0, 1, A[i], 1));
+  }, {VERIFY(0, 1, A[i], 1); any_fail += fail;});
 
   //
   // Test: omp_in_final()
@@ -330,7 +331,7 @@ int main(void) {
 	  A[0] += omp_in_final();  // 1  always returns true.
 	}
       }
-    }, VERIFY(0, 1, A[i], omp_is_initial_device() ? 0 : 2));
+    }, {VERIFY(0, 1, A[i], omp_is_initial_device() ? 0 : 2); any_fail += fail;});
 
   //
   // Test: omp_get_proc_bind()
@@ -345,7 +346,7 @@ int main(void) {
         A[0] += omp_get_proc_bind();  // 1  always returns omp_proc_bind_true.
       }
     }
-    },  VERIFY(0, 1, A[i], omp_is_initial_device() ? 0 : 2));
+    },  {VERIFY(0, 1, A[i], omp_is_initial_device() ? 0 : 2); any_fail += fail;});
 
 #if 0
   //
@@ -364,7 +365,7 @@ int main(void) {
       int *place_nums;
       omp_get_partition_place_nums(place_nums);
     }
-  }, VERIFY(0, 1, A[i], 0));
+  }, {VERIFY(0, 1, A[i], 0); any_fail += fail;});
 #endif
 
   //
@@ -384,7 +385,7 @@ int main(void) {
         A[0] += omp_get_default_device();  // 0  always returns 0.
       }
     }
-  }, VERIFY(0, 1, A[i], 0));
+  }, {VERIFY(0, 1, A[i], 0); any_fail += fail;});
 
   //
   // Test: omp_get_num_devices(). Undefined on the target.
@@ -399,7 +400,7 @@ int main(void) {
         A[1] = omp_get_num_devices();
       }
     }
-  }, VERIFY(0, 1, A[i], A[i] - A[1]));
+  }, {VERIFY(0, 1, A[i], A[i] - A[1]); any_fail += fail;});
 
   //
   // Test: omp_get_num_teams(), omp_get_team_num()
@@ -416,7 +417,7 @@ int main(void) {
         A[0] += omp_get_team_num();   // 0
       }
     }
-  }, VERIFY(0, 1, A[i], 2));
+  }, {VERIFY(0, 1, A[i], 2); any_fail += fail;});
 
   //
   // Test: omp_is_initial_device()
@@ -432,7 +433,7 @@ int main(void) {
         A[0] += omp_is_initial_device();  // 0
       }
     }
-    }, VERIFY(0, 1, A[i], omp_is_initial_device() ? A[1] - A[1] : 2.0));
+    }, {VERIFY(0, 1, A[i], omp_is_initial_device() ? A[1] - A[1] : 2.0); any_fail += fail;});
 
   return 0;
 
@@ -451,7 +452,7 @@ int main(void) {
         A[0] -= omp_get_initial_device();
       }
     }
-  }, VERIFY(0, 1, A[i], 0));
+  }, {VERIFY(0, 1, A[i], 0); any_fail += fail;});
 #endif
 
 #if 0
@@ -469,7 +470,7 @@ int main(void) {
         A[0] -= omp_get_max_task_priority();
       }
     }
-  }, VERIFY(0, 1, A[i], 0));
+  }, {VERIFY(0, 1, A[i], 0); any_fail += fail;});
 #endif
 
 
@@ -487,7 +488,7 @@ int main(void) {
       start = omp_get_wtime();
       end = omp_get_wtime();
     }
-  }, VERIFY(0, 1, A[i], 0));
+  },  {VERIFY(0, 1, A[i], 0); any_fail += fail;});
 
-  return 0;
+  return any_fail > 0;
 }

--- a/t-target-parallel-for-simd/test.c
+++ b/t-target-parallel-for-simd/test.c
@@ -31,6 +31,7 @@
 //
 
 int main(void) {
+  int any_fail = 0;
   check_offloading();
 
   double A[N], B[N], C[N], D[N], E[N];
@@ -74,7 +75,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR2(
     {
@@ -94,7 +95,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR3(
     {
@@ -114,7 +115,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR4(
     {
@@ -134,7 +135,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR5(
     {
@@ -154,7 +155,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR6(
     {
@@ -174,7 +175,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR7(
     {
@@ -194,7 +195,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR8(
     {
@@ -214,7 +215,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR9(
     {
@@ -234,7 +235,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
   }
   DUMP_SUCCESS9()
 
@@ -261,7 +262,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR2(
     {
@@ -281,7 +282,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR3(
     {
@@ -301,7 +302,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR4(
     {
@@ -321,7 +322,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR5(
     {
@@ -341,7 +342,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR6(
     {
@@ -361,7 +362,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR7(
     {
@@ -381,7 +382,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR8(
     {
@@ -401,7 +402,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR9(
     {
@@ -421,7 +422,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
   }
   DUMP_SUCCESS9()
 
@@ -448,7 +449,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR2(
     {
@@ -468,7 +469,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR3(
     {
@@ -488,7 +489,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR4(
     {
@@ -508,7 +509,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR5(
     {
@@ -528,7 +529,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR6(
     {
@@ -548,7 +549,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR7(
     {
@@ -568,7 +569,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR8(
     {
@@ -588,7 +589,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR9(
     {
@@ -608,7 +609,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
   }
   DUMP_SUCCESS9()
 
@@ -643,7 +644,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], 6 + N/2*(N+1)))
+    {VERIFY(0, 1, S[0], 6 + N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR2(
       double p = 2; \
@@ -666,7 +667,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], 6 + N/2*(N+1)))
+    {VERIFY(0, 1, S[0], 6 + N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR3(
       double p = 2; \
@@ -689,7 +690,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], 6 + N/2*(N+1)))
+    {VERIFY(0, 1, S[0], 6 + N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR4(
       double p = 2; \
@@ -712,7 +713,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], 6 + N/2*(N+1)))
+    {VERIFY(0, 1, S[0], 6 + N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR5(
       double p = 2; \
@@ -735,7 +736,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], 6 + N/2*(N+1)))
+    {VERIFY(0, 1, S[0], 6 + N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR6(
       double p = 2; \
@@ -758,7 +759,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], 6 + N/2*(N+1)))
+    {VERIFY(0, 1, S[0], 6 + N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR7(
       double p = 2; \
@@ -781,7 +782,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], 6 + N/2*(N+1)))
+    {VERIFY(0, 1, S[0], 6 + N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR8(
       double p = 2; \
@@ -804,7 +805,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], 6 + N/2*(N+1)))
+    {VERIFY(0, 1, S[0], 6 + N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR9(
       double p = 2; \
@@ -827,7 +828,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], 6 + N/2*(N+1)))
+    {VERIFY(0, 1, S[0], 6 + N/2*(N+1)); any_fail += fail; })
   }
   DUMP_SUCCESS9()
 
@@ -862,7 +863,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR2(
       double p = -4; \
@@ -887,7 +888,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR3(
       double p = -4; \
@@ -912,7 +913,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR4(
       double p = -4; \
@@ -937,7 +938,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR5(
       double p = -4; \
@@ -962,7 +963,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR6(
       double p = -4; \
@@ -987,7 +988,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR7(
       double p = -4; \
@@ -1012,7 +1013,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR8(
       double p = -4; \
@@ -1037,7 +1038,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR9(
       double p = -4; \
@@ -1062,7 +1063,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
   }
   DUMP_SUCCESS9()
 
@@ -1098,7 +1099,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N+1+ N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N+1+ N/2*(N+1)); any_fail += fail; })
   }
 
   FIXME: private of non-scalar does not work.
@@ -1131,7 +1132,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], 6 + SUMS * (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], 6 + SUMS * (N/2*(N+1))); any_fail += fail; })
   }
 
   FIXME: private of non-scalar does not work.
@@ -1166,7 +1167,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))); any_fail += fail; })
   }
 #endif
 
@@ -1198,7 +1199,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], (N/2*(N+1))); any_fail += fail; })
 
     TARGET_PARALLEL_FOR2(
       S[0] = 0; \
@@ -1220,7 +1221,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], (N/2*(N+1))); any_fail += fail; })
 
     TARGET_PARALLEL_FOR3(
       S[0] = 0; \
@@ -1242,7 +1243,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], (N/2*(N+1))); any_fail += fail; })
 
     TARGET_PARALLEL_FOR4(
       S[0] = 0; \
@@ -1264,7 +1265,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], (N/2*(N+1))); any_fail += fail; })
 
     TARGET_PARALLEL_FOR5(
       S[0] = 0; \
@@ -1286,7 +1287,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], (N/2*(N+1))); any_fail += fail; })
 
     TARGET_PARALLEL_FOR6(
       S[0] = 0; \
@@ -1308,7 +1309,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], (N/2*(N+1))); any_fail += fail; })
 
     TARGET_PARALLEL_FOR7(
       S[0] = 0; \
@@ -1330,7 +1331,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], (N/2*(N+1))); any_fail += fail; })
 
     TARGET_PARALLEL_FOR8(
       S[0] = 0; \
@@ -1352,7 +1353,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], (N/2*(N+1))); any_fail += fail; })
 
     TARGET_PARALLEL_FOR9(
       S[0] = 0; \
@@ -1374,7 +1375,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], (N/2*(N+1))); any_fail += fail; })
   }
   DUMP_SUCCESS9()
  
@@ -1403,7 +1404,7 @@ int main(void) {
       }
       S[0] = tmp;
     },
-    VERIFY(0, 1, S[0], (32*32 + 64*32) ))
+    {VERIFY(0, 1, S[0], (32*32 + 64*32) ); any_fail += fail; })
 
     TARGET_PARALLEL_FOR2(
       S[0] = 0; \
@@ -1422,7 +1423,7 @@ int main(void) {
       }
       S[0] = tmp;
     },
-    VERIFY(0, 1, S[0], (32*32 + 64*32) ))
+    {VERIFY(0, 1, S[0], (32*32 + 64*32) ); any_fail += fail; })
 
     TARGET_PARALLEL_FOR7(
       S[0] = 0; \
@@ -1441,11 +1442,11 @@ int main(void) {
       }
       S[0] = tmp;
     },
-    VERIFY(0, 1, S[0], (32*32 + 64*32) ))
+    {VERIFY(0, 1, S[0], (32*32 + 64*32) ); any_fail += fail; })
   } else {
     DUMP_SUCCESS(3);
   }
 
-  return 0;
+  return any_fail > 0;
 }
 

--- a/t-target-parallel-for/test.c
+++ b/t-target-parallel-for/test.c
@@ -31,6 +31,7 @@
 //
 
 int main(void) {
+  int any_fail = 0;
   check_offloading();
 
   double A[N], B[N], C[N], D[N], E[N];
@@ -74,7 +75,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR2(
     {
@@ -94,7 +95,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR3(
     {
@@ -114,7 +115,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR4(
     {
@@ -134,7 +135,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR5(
     {
@@ -154,7 +155,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR6(
     {
@@ -174,7 +175,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR7(
     {
@@ -194,7 +195,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR8(
     {
@@ -214,7 +215,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR9(
     {
@@ -234,7 +235,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
   }
   DUMP_SUCCESS9()
 
@@ -261,7 +262,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR2(
     {
@@ -281,7 +282,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR3(
     {
@@ -301,7 +302,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR4(
     {
@@ -321,7 +322,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR5(
     {
@@ -341,7 +342,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR6(
     {
@@ -361,7 +362,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR7(
     {
@@ -381,7 +382,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR8(
     {
@@ -401,7 +402,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR9(
     {
@@ -421,7 +422,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
   }
   DUMP_SUCCESS9()
 
@@ -448,7 +449,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR2(
     {
@@ -468,7 +469,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR3(
     {
@@ -488,7 +489,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR4(
     {
@@ -508,7 +509,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR5(
     {
@@ -528,7 +529,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR6(
     {
@@ -548,7 +549,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR7(
     {
@@ -568,7 +569,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR8(
     {
@@ -588,7 +589,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR9(
     {
@@ -608,7 +609,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
   }
   DUMP_SUCCESS9()
 
@@ -643,7 +644,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], 6 + N/2*(N+1)))
+    {VERIFY(0, 1, S[0], 6 + N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR2(
       double p = 2; \
@@ -666,7 +667,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], 6 + N/2*(N+1)))
+    {VERIFY(0, 1, S[0], 6 + N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR3(
       double p = 2; \
@@ -689,7 +690,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], 6 + N/2*(N+1)))
+    {VERIFY(0, 1, S[0], 6 + N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR4(
       double p = 2; \
@@ -712,7 +713,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], 6 + N/2*(N+1)))
+    {VERIFY(0, 1, S[0], 6 + N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR5(
       double p = 2; \
@@ -735,7 +736,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], 6 + N/2*(N+1)))
+    {VERIFY(0, 1, S[0], 6 + N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR6(
       double p = 2; \
@@ -758,7 +759,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], 6 + N/2*(N+1)))
+    {VERIFY(0, 1, S[0], 6 + N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR7(
       double p = 2; \
@@ -781,7 +782,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], 6 + N/2*(N+1)))
+    {VERIFY(0, 1, S[0], 6 + N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR8(
       double p = 2; \
@@ -804,7 +805,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], 6 + N/2*(N+1)))
+    {VERIFY(0, 1, S[0], 6 + N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR9(
       double p = 2; \
@@ -827,7 +828,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], 6 + N/2*(N+1)))
+    {VERIFY(0, 1, S[0], 6 + N/2*(N+1)); any_fail += fail;})
   }
   DUMP_SUCCESS9()
 
@@ -862,7 +863,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR2(
       double p = -4; \
@@ -887,7 +888,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR3(
       double p = -4; \
@@ -912,7 +913,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR4(
       double p = -4; \
@@ -937,7 +938,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR5(
       double p = -4; \
@@ -962,7 +963,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR6(
       double p = -4; \
@@ -987,7 +988,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR7(
       double p = -4; \
@@ -1012,7 +1013,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR8(
       double p = -4; \
@@ -1037,7 +1038,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR9(
       double p = -4; \
@@ -1062,7 +1063,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
   }
   DUMP_SUCCESS9()
 
@@ -1100,7 +1101,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N+1+ N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N+1+ N/2*(N+1)); any_fail += fail;})
   }
 
   FIXME: private of non-scalar does not work.
@@ -1133,7 +1134,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], 6 + SUMS * (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], 6 + SUMS * (N/2*(N+1))); any_fail += fail;})
   }
 
   FIXME: private of non-scalar does not work.
@@ -1168,7 +1169,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))); any_fail += fail;})
   }
 #endif
 
@@ -1200,7 +1201,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], (N/2*(N+1))); any_fail += fail;})
 
     TARGET_PARALLEL_FOR2(
       S[0] = 0; \
@@ -1222,7 +1223,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], (N/2*(N+1))); any_fail += fail;})
 
     TARGET_PARALLEL_FOR3(
       S[0] = 0; \
@@ -1244,7 +1245,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], (N/2*(N+1))); any_fail += fail;})
 
     TARGET_PARALLEL_FOR4(
       S[0] = 0; \
@@ -1266,7 +1267,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], (N/2*(N+1))); any_fail += fail;})
 
     TARGET_PARALLEL_FOR5(
       S[0] = 0; \
@@ -1288,7 +1289,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], (N/2*(N+1))); any_fail += fail;})
 
     TARGET_PARALLEL_FOR6(
       S[0] = 0; \
@@ -1310,7 +1311,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], (N/2*(N+1))); any_fail += fail;})
 
     TARGET_PARALLEL_FOR7(
       S[0] = 0; \
@@ -1332,7 +1333,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], (N/2*(N+1))); any_fail += fail;})
 
     TARGET_PARALLEL_FOR8(
       S[0] = 0; \
@@ -1354,7 +1355,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], (N/2*(N+1))); any_fail += fail;})
 
     TARGET_PARALLEL_FOR9(
       S[0] = 0; \
@@ -1376,7 +1377,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], (N/2*(N+1))); any_fail += fail;})
   }
   DUMP_SUCCESS9()
 
@@ -1398,7 +1399,7 @@ int main(void) {
     ,
     {
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR2(
       S[0] = 0; \
@@ -1410,7 +1411,7 @@ int main(void) {
     ,
     {
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR3(
       S[0] = 0; \
@@ -1422,7 +1423,7 @@ int main(void) {
     ,
     {
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR4(
       S[0] = 0; \
@@ -1434,7 +1435,7 @@ int main(void) {
     ,
     {
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR5(
       S[0] = 0; \
@@ -1446,7 +1447,7 @@ int main(void) {
     ,
     {
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR6(
       S[0] = 0; \
@@ -1458,7 +1459,7 @@ int main(void) {
     ,
     {
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR7(
       S[0] = 0; \
@@ -1470,7 +1471,7 @@ int main(void) {
     ,
     {
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR8(
       S[0] = 0; \
@@ -1482,7 +1483,7 @@ int main(void) {
     ,
     {
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR9(
       S[0] = 0; \
@@ -1494,7 +1495,7 @@ int main(void) {
     ,
     {
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
   }
   DUMP_SUCCESS9()
 
@@ -1523,7 +1524,7 @@ int main(void) {
       }
       S[0] = tmp;
     },
-    VERIFY(0, 1, S[0], (32*32 + 64*32) ))
+    {VERIFY(0, 1, S[0], (32*32 + 64*32) ); any_fail += fail;})
 
     TARGET_PARALLEL_FOR2(
       S[0] = 0; \
@@ -1542,7 +1543,7 @@ int main(void) {
       }
       S[0] = tmp;
     },
-    VERIFY(0, 1, S[0], (32*32 + 64*32) ))
+    {VERIFY(0, 1, S[0], (32*32 + 64*32) ); any_fail += fail;})
 
     TARGET_PARALLEL_FOR7(
       S[0] = 0; \
@@ -1561,11 +1562,11 @@ int main(void) {
       }
       S[0] = tmp;
     },
-    VERIFY(0, 1, S[0], (32*32 + 64*32) ))
+    {VERIFY(0, 1, S[0], (32*32 + 64*32) ); any_fail += fail;})
   } else {
     DUMP_SUCCESS(3);
   }
 
-  return 0;
+  return any_fail > 0;
 }
 

--- a/t-target-parallel/test.c
+++ b/t-target-parallel/test.c
@@ -15,6 +15,7 @@
 #define ZERO(X) ZERO_ARRAY(N, X)
 
 int main(void) {
+  int any_fail = 0;
   check_offloading();
 
   double A[N], B[N], C[N], D[N], E[N];
@@ -36,7 +37,7 @@ int main(void) {
   TESTD("omp target parallel num_threads(max_threads)", {
     int tid = omp_get_thread_num();
     A[tid] += tid;
-  }, VERIFY(0,  max_threads, A[i], i*(trial+1)));
+  }, {VERIFY(0,  max_threads, A[i], i*(trial+1)); any_fail += fail;});
 
   //
   // Test: Execute parallel on device
@@ -46,7 +47,7 @@ int main(void) {
       for (int j = i; j < i + 4; j++) {
         B[j] = D[j] + E[j];
       }
-    }, VERIFY(0, max_threads*4, B[i], (double)0));
+    }, {VERIFY(0, max_threads*4, B[i], (double)0); any_fail += fail;});
 
   //
   // Test: if clause serial execution of parallel region on host
@@ -55,7 +56,7 @@ int main(void) {
   TESTD("omp target parallel num_threads(max_threads) if(0)", {
       int tid = omp_get_thread_num();
       A[tid] = tid;
-  }, VERIFY(0, max_threads, A[i], 0));
+  }, {VERIFY(0, max_threads, A[i], 0); any_fail += fail;});
 
   //
   // Test: if clause parallel execution of parallel region on device
@@ -64,7 +65,7 @@ int main(void) {
   TESTD("omp target parallel num_threads(max_threads) if(A[0] == 0)", {
       int tid = omp_get_thread_num();
       A[tid] = tid + omp_is_initial_device();
-  }, VERIFY(0, max_threads, A[i], i + cpuExec));
+  }, {VERIFY(0, max_threads, A[i], i + cpuExec); any_fail += fail;});
 
   //
   // Test: if clause serial execution of parallel region on device
@@ -73,7 +74,7 @@ int main(void) {
   TESTD("omp target parallel num_threads(max_threads) if(parallel: 0)", {
       int tid = omp_get_thread_num();
       A[tid] = !omp_is_initial_device();
-  }, VERIFY(0, max_threads, A[i], i == 0 ? 1 - cpuExec : 0));
+  }, {VERIFY(0, max_threads, A[i], i == 0 ? 1 - cpuExec : 0); any_fail += fail;});
 
 
   //
@@ -83,7 +84,7 @@ int main(void) {
   TESTD("omp target parallel num_threads(max_threads) if(target: 0) if(parallel: A[0] == 0)", {
       int tid = omp_get_thread_num();
       A[tid] = tid + omp_is_initial_device();
-  }, VERIFY(0, /* bound to */ cpu_threads, A[i], i+1));
+  }, {VERIFY(0, /* bound to */ cpu_threads, A[i], i+1); any_fail += fail;});
 
 
   //
@@ -93,7 +94,7 @@ int main(void) {
   TESTD("omp target parallel if(parallel: A[0] > 0)", {
       int tid = omp_get_thread_num();
       A[tid] = omp_get_num_threads();
-  }, VERIFY(0, 1, A[0], 1));
+  }, {VERIFY(0, 1, A[0], 1); any_fail += fail;});
 
   //
   // Test: if clause parallel execution of parallel region on device without num_threads clause
@@ -108,7 +109,7 @@ int main(void) {
   TESTD("omp target parallel if(parallel: A[0] == 0)", {
       int tid = omp_get_thread_num();
       A[tid] = omp_get_num_threads();
-  }, VERIFY(0, 1, A[0], B[0]));
+  }, {VERIFY(0, 1, A[0], B[0]); any_fail += fail;});
 
   //
   // Test: if clause parallel execution of parallel region on device with num_threads clause
@@ -117,7 +118,7 @@ int main(void) {
   TESTD("omp target parallel num_threads(1) if(parallel: A[0] == 0)", {
       int tid = omp_get_thread_num();
       A[tid] = omp_get_num_threads();
-  }, VERIFY(0, 1, A[0], 1));
+  }, {VERIFY(0, 1, A[0], 1); any_fail += fail;});
 
   //
   // Test: proc_bind clause
@@ -127,19 +128,19 @@ int main(void) {
       for (int j = i; j < i + 4; j++) {
         B[j] = 1 + D[j] + E[j];
       }
-  }, VERIFY(0, max_threads*4, B[i], 1));
+  }, {VERIFY(0, max_threads*4, B[i], 1); any_fail += fail;});
   TESTD("omp target parallel num_threads(max_threads) proc_bind(close)", {
       int i = omp_get_thread_num()*4;
       for (int j = i; j < i + 4; j++) {
         B[j] = 1 + D[j] + E[j];
       }
-  }, VERIFY(0, max_threads*4, B[i], 1));
+  }, {VERIFY(0, max_threads*4, B[i], 1); any_fail += fail;});
   TESTD("omp target parallel num_threads(max_threads) proc_bind(spread)", {
       int i = omp_get_thread_num()*4;
       for (int j = i; j < i + 4; j++) {
         B[j] = 1 + D[j] + E[j];
       }
-  }, VERIFY(0, max_threads*4, B[i], 1));
+  }, {VERIFY(0, max_threads*4, B[i], 1); any_fail += fail;});
 
   //
   // Test: num_threads on parallel.
@@ -150,7 +151,7 @@ int main(void) {
     TESTD("omp target parallel num_threads(threads[0])", {
         int tid = omp_get_thread_num();
         A[tid] = 99;
-    }, VERIFY(0, 128, A[i], 99*(i < t)));
+    }, {VERIFY(0, 128, A[i], 99*(i < t)); any_fail += fail;});
   }
   DUMP_SUCCESS(gpu_threads-max_threads);
 
@@ -164,7 +165,7 @@ int main(void) {
     TESTD("omp target parallel map(tofrom: tmp) num_threads(1)", {
         tmp = 2;
         A[0] += tmp;
-    }, VERIFY(0, 1, A[i]+tmp, (1+trial)*2+1+2));
+    }, {VERIFY(0, 1, A[i]+tmp, (1+trial)*2+1+2); any_fail += fail;});
   }
 
   //
@@ -179,7 +180,7 @@ int main(void) {
         p[0] = 2;
         q = 0;
         A[0] += p[0];
-    }, VERIFY(0, 1, A[i]+p[0]+q, (1+trial)*2+2+99));
+    }, {VERIFY(0, 1, A[i]+p[0]+q, (1+trial)*2+2+99); any_fail += fail;});
   }
 
   //
@@ -194,7 +195,7 @@ int main(void) {
         A[0] += p[0] + q;
         p[0] = 2;
         q = 0;
-    }, VERIFY(0, 1, A[i]+p[0]+q, (1+trial)*(99+5)+5+5+99));
+    }, {VERIFY(0, 1, A[i]+p[0]+q, (1+trial)*(99+5)+5+5+99); any_fail += fail;});
   }
 
 #if 0
@@ -217,9 +218,9 @@ int main(void) {
           A[0] += p[0] + q;
         _Pragma("omp barrier")
         p[0] = 1; q = -100;
-    }, VERIFY(0, 1, A[i]+p[0]+q, (1+trial)*(99+2)+5+-7));
+    }, {VERIFY(0, 1, A[i]+p[0]+q, (1+trial)*(99+2)+5+-7); any_fail += fail;});
   }
 #endif
 
-  return 0;
+  return any_fail > 0;
 }

--- a/t-target-teams/test.c
+++ b/t-target-teams/test.c
@@ -16,6 +16,7 @@
 #define ZERO(X) ZERO_ARRAY(N, X)
 
 int main(void) {
+  int any_fail = 0;
   check_offloading();
 
   double A[N], B[N], C[N], D[N], E[N];
@@ -67,6 +68,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: map clause
@@ -88,6 +90,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: num_teams and omp_get_team_num()
@@ -107,6 +110,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: thread_limit and omp_get_thread_num()
@@ -129,6 +133,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: if statement in teams region
@@ -163,6 +168,7 @@ int main(void) {
   }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   /* // */
   /* // Test: num_teams and thread_limit by simulating a distribute pragma */
@@ -204,6 +210,7 @@ int main(void) {
   /* } */
   /* if(fail) printf("Failed\n"); */
   /* else printf("Succeeded\n"); */
+  /* any_fail += fail; */
 
   //
   // Test: private
@@ -227,6 +234,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: firstprivate
@@ -250,6 +258,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
   
-  return 0;
+  return any_fail > 0;
 }

--- a/t-teams/test.c
+++ b/t-teams/test.c
@@ -16,6 +16,7 @@
 #define ZERO(X) ZERO_ARRAY(N, X)
 
 int main(void) {
+  int any_fail = 0;
   check_offloading();
 
   double A[N], B[N], C[N], D[N], E[N];
@@ -42,6 +43,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: thread_limit and omp_get_thread_num()
@@ -65,6 +67,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
 
   //
@@ -101,6 +104,7 @@ int main(void) {
   }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   /* // */
   /* // Test: num_teams and thread_limit by simulating a distribute pragma */
@@ -143,6 +147,7 @@ int main(void) {
   /* } */
   /* if(fail) printf("Failed\n"); */
   /* else printf("Succeeded\n"); */
+  /* any_fail += fail; */
 
   //
   // Test: private
@@ -167,6 +172,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   ZERO(A);
   fail = 0;
@@ -188,6 +194,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   ZERO(A);
   fail = 0;
@@ -209,6 +216,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   ZERO(A);
   fail = 0;
@@ -230,6 +238,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
-  return 0;
+  return any_fail;
 }

--- a/t-unified-barrier/test.c
+++ b/t-unified-barrier/test.c
@@ -101,6 +101,7 @@ _Pragma("omp parallel num_threads(16)") { \
 }
 
 int main(void) {
+  int any_fail = 0;
   check_offloading();
 
   double A[N+2], B[N+2], C[N+2], D[N+2], E[N+2];
@@ -121,7 +122,7 @@ int main(void) {
   //
   TESTD("omp target teams num_teams(1) thread_limit(32)", {
     PARALLEL_A()
-  }, VERIFY(0, 1, B[i], i+1));
+  }, {VERIFY(0, 1, B[i], i+1); any_fail += fail;});
 
   //
   // Test: Barrier in a parallel region.
@@ -131,7 +132,7 @@ int main(void) {
     TESTD("omp target teams num_teams(1) thread_limit(max_threads)", {
     ZERO(B);
     PARALLEL_B5()
-    }, VERIFY(0, threads[0]-1, B[i], 5));
+    }, {VERIFY(0, threads[0]-1, B[i], 5); any_fail += fail;});
   }
   DUMP_SUCCESS(gpu_threads-max_threads);
 
@@ -144,15 +145,15 @@ int main(void) {
     int threads[1]; threads[0] = t;
     PARALLEL_B()
   }
-  }, VERIFY(0, max_threads-1, B[i], (max_threads / 32) - (i+1) / 32));
+  }, {VERIFY(0, max_threads-1, B[i], (max_threads / 32) - (i+1) / 32); any_fail += fail;});
 
   //
   // Test: Single thread in target region.
   //
-  TESTD("#pragma omp target", {
+  TESTD("omp target", {
   ZERO(B);
   BODY_B()
-  }, VERIFY(0, 1, C[i], 491535));
+  }, {VERIFY(0, 1, C[i], 491535); any_fail += fail;});
 
   //
   // Test: Barrier in target parallel.
@@ -162,7 +163,7 @@ int main(void) {
     int threads; threads = t;
     TESTD("omp target parallel num_threads(threads)", {
       BODY_B();
-    }, VERIFY(0, t-1, B[i], (trial+1)*1.0));
+    }, {VERIFY(0, t-1, B[i], (trial+1)*1.0); any_fail += fail;});
   }
   DUMP_SUCCESS(gpu_threads-max_threads);
 
@@ -174,7 +175,7 @@ int main(void) {
     ZERO(B);
     TEST({
       BODY_NP();
-    }, VERIFY(0, 16*16, B[i], (i > 0 && (i+1) % 16 == 0 ? 0 : (trial+1)*1)) );
+    }, {VERIFY(0, 16*16, B[i], (i > 0 && (i+1) % 16 == 0 ? 0 : (trial+1)*1)); any_fail += fail;} );
   } else {
     DUMP_SUCCESS(1);
   }
@@ -185,4 +186,5 @@ int main(void) {
   // target + simd
   // target/teams/parallel with varying numbers of threads
 
+  return any_fail > 0;
 }

--- a/t-unified-for-simd/test.c
+++ b/t-unified-for-simd/test.c
@@ -53,6 +53,7 @@
 
 int main ()
 {
+  int any_fail = 0;
   int a[N], b[N], c[N];
 
 #if TEST1
@@ -93,6 +94,7 @@ int main ()
       printf ("Failed 2\n");
     else
       printf("Succeeded 2\n");
+    any_fail += fail;
 #endif
 
 #if TEST3
@@ -134,6 +136,7 @@ int main ()
       printf ("Failed 3\n");
     else
       printf("Succeeded 3\n");
+    any_fail += fail;
 #endif
 
 #if TEST4
@@ -163,6 +166,7 @@ int main ()
       printf ("Failed 4\n");
     else
       printf("Succeeded 4\n");
+    any_fail += fail;
 #endif
 
 #if TEST5
@@ -192,6 +196,7 @@ int main ()
       printf ("Failed 5\n");
     else
       printf("Succeeded 5\n");  
+    any_fail += fail;
 #endif
 
 #if TEST6
@@ -221,6 +226,7 @@ int main ()
       printf ("Failed 6\n");
     else
       printf("Succeeded 6\n");  
+    any_fail += fail;
 #endif
 
 #if TEST7
@@ -251,6 +257,7 @@ int main ()
       printf ("Failed 7\n");
     else
       printf("Succeeded 7\n");
+    any_fail += fail;
 #endif
 
 #if TEST8
@@ -281,6 +288,7 @@ int main ()
       printf ("Failed 8\n");
     else
       printf("Succeeded 8\n");
+    any_fail += fail;
 #endif
 
 #if TEST9
@@ -311,6 +319,7 @@ int main ()
       printf ("Failed 9\n");
     else
       printf("Succeeded 9\n");
+    any_fail += fail;
 #endif
 
 #if TEST10
@@ -340,6 +349,7 @@ int main ()
       printf ("Failed 10\n");
     else
       printf("Succeeded 10\n");
+    any_fail += fail;
 #endif
 
 #if TEST11 && TEST_BROKEN // hangs
@@ -369,6 +379,7 @@ int main ()
       printf ("Failed 11\n");
     else
       printf("Succeeded 11\n");
+    any_fail += fail;
 #endif
 
 #if TEST12 && TEST_BROKEN // hangs
@@ -398,6 +409,7 @@ int main ()
       printf ("Failed 12\n");
     else
       printf("Succeeded 12\n");
+    any_fail += fail;
 #endif
 
 #if TEST13
@@ -427,6 +439,7 @@ int main ()
       printf ("Failed 13\n");
     else
       printf("Succeeded 13\n");
+    any_fail += fail;
 #endif
 
 #if TEST14
@@ -457,6 +470,7 @@ int main ()
       printf ("Failed 14\n");
     else
       printf("Succeeded 14\n");
+    any_fail += fail;
 #endif
 
 #if TEST15 && TEST_BROKEN
@@ -487,6 +501,7 @@ int main ()
       printf ("Failed 15\n");
     else
       printf("Succeeded 15\n");
+    any_fail += fail;
 #endif
 
 #if TEST16 && TEST_BROKEN
@@ -517,6 +532,7 @@ int main ()
       printf ("Failed 16\n");
     else
       printf("Succeeded 16\n");
+    any_fail += fail;
 #endif
 
 #if TEST17
@@ -547,6 +563,7 @@ int main ()
       printf ("Failed 17\n");
     else
       printf("Succeeded 17\n");
+    any_fail += fail;
 #endif
 
 #if TEST18
@@ -576,6 +593,7 @@ int main ()
       printf ("Failed 18\n");
     else
       printf("Succeeded 18\n");
+    any_fail += fail;
 #endif
 
 #if TEST19 && TEST_BROKEN
@@ -605,6 +623,7 @@ int main ()
       printf ("Failed 19\n");
     else
       printf("Succeeded 19\n");
+    any_fail += fail;
 #endif
 
 #if TEST20 && TEST_BROKEN
@@ -634,6 +653,7 @@ int main ()
       printf ("Failed 20\n");
     else
       printf("Succeeded 20\n");
+    any_fail += fail;
 #endif
 
 #if TEST21
@@ -663,6 +683,7 @@ int main ()
       printf ("Failed 21\n");
     else
       printf("Succeeded 21\n");
+    any_fail += fail;
 #endif
 
 #if TEST22
@@ -693,6 +714,7 @@ int main ()
       printf ("Failed 22\n");
     else
       printf("Succeeded 22\n");
+    any_fail += fail;
 #endif
 
 #if TEST23 && TEST_BROKEN
@@ -723,6 +745,7 @@ int main ()
       printf ("Failed 23\n");
     else
       printf("Succeeded 23\n");
+    any_fail += fail;
 #endif
 
 #if TEST24 && TEST_BROKEN
@@ -753,6 +776,7 @@ int main ()
       printf ("Failed 24\n");
     else
       printf("Succeeded 24\n");
+    any_fail += fail;
 #endif
 
 #if TEST25
@@ -783,6 +807,7 @@ int main ()
       printf ("Failed 25\n");
     else
       printf("Succeeded 25\n");
+    any_fail += fail;
 #endif
 
 #if TEST26
@@ -812,6 +837,7 @@ int main ()
       printf ("Failed 26\n");
     else
       printf("Succeeded 26\n");
+    any_fail += fail;
 #endif
 
 #if TEST27
@@ -841,6 +867,7 @@ int main ()
       printf ("Failed 27\n");
     else
       printf("Succeeded 27\n");
+    any_fail += fail;
 #endif
 
 #if TEST28
@@ -869,6 +896,7 @@ int main ()
       printf ("Failed 28\n");
     else
       printf("Succeeded 28\n");
+    any_fail += fail;
 #endif
 
 #if TEST29
@@ -898,6 +926,7 @@ int main ()
       printf ("Failed 29\n");
     else
       printf("Succeeded 29\n");
+    any_fail += fail;
 #endif
 
 #if TEST30 && TEST_BROKEN
@@ -927,6 +956,7 @@ int main ()
       printf ("Failed 30\n");
     else
       printf("Succeeded 30\n");
+    any_fail += fail;
 #endif
 
 #if TEST31
@@ -956,6 +986,7 @@ int main ()
       printf ("Failed 31\n");
     else
       printf("Succeeded 31\n");
+    any_fail += fail;
 #endif
 
 #if TEST32
@@ -989,6 +1020,7 @@ int main ()
       printf ("Failed 32\n");
     else
       printf("Succeeded 32\n");
+    any_fail += fail;
 #endif
 
 #if TEST33
@@ -1018,6 +1050,7 @@ int main ()
       printf ("Failed 33\n");
     else
       printf("Succeeded 33\n");
+    any_fail += fail;
 #endif
 
 #if TEST34
@@ -1047,6 +1080,7 @@ int main ()
       printf ("Failed 34\n");
     else
       printf("Succeeded 34\n");
+    any_fail += fail;
 #endif
 
 #if TEST35
@@ -1076,6 +1110,7 @@ int main ()
       printf ("Failed 35\n");
     else
       printf("Succeeded 35\n");
+    any_fail += fail;
 #endif
 
 #if TEST36
@@ -1105,6 +1140,7 @@ int main ()
       printf ("Failed 36\n");
     else
       printf("Succeeded 36\n");
+    any_fail += fail;
 #endif
 
 #if TEST37
@@ -1134,7 +1170,8 @@ int main ()
       printf ("Failed 37\n");
     else
       printf("Succeeded 37\n");
+    any_fail += fail;
 #endif
   
-  return 0;
+  return any_fail > 0;
 }

--- a/t-unified-for/test.c
+++ b/t-unified-for/test.c
@@ -16,6 +16,7 @@
 #define ZERO(X) ZERO_ARRAY(N, X)
 
 int main(void) {
+  int any_fail = 0;
   check_offloading();
 
   double A[N], B[N], C[N], D[N], E[N];
@@ -54,7 +55,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))); any_fail += fail;})
   }
 
   //
@@ -87,7 +88,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], 6 + SUMS * (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], 6 + SUMS * (N/2*(N+1))); any_fail += fail;})
   }
 
   //
@@ -122,7 +123,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))); any_fail += fail;})
   }
 
   //
@@ -195,7 +196,7 @@ int main(void) {
         tmp += A[i] + B[i];
       }
       S[0] += tmp;
-    }, VERIFY(0, 1, S[0], 5 * (N + (N/2*(N+1))) ));
+    }, {VERIFY(0, 1, S[0], 5 * (N + (N/2*(N+1))) ); any_fail += fail;});
   }
 
   //
@@ -227,7 +228,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], 6 + SUMS * (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], 6 + SUMS * (N/2*(N+1))); any_fail += fail;})
   }
 
   //
@@ -261,7 +262,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))); any_fail += fail;})
   }
 
   //
@@ -292,7 +293,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))); any_fail += fail;})
   }
 
   //
@@ -313,7 +314,7 @@ int main(void) {
     ,
     {
     },
-    VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))); any_fail += fail;})
   }
 
   //
@@ -346,7 +347,7 @@ int main(void) {
           S[0] += tmp;
         }
       }
-    }, VERIFY(0, 1, S[0], (N/2*(N+1)) ));
+    }, {VERIFY(0, 1, S[0], (N/2*(N+1)) ); any_fail += fail;});
   }
   //
   // Test: Ensure coalesced scheduling on GPU.
@@ -397,7 +398,7 @@ int main(void) {
         tmp += A[i];
       }
       S[0] = tmp;
-    }, VERIFY(0, 1, S[0], 3 * ( 99 * 98 * 0.5 - 3 * 0.5 * nthreads * (nthreads - 1) - 0.5 * residual * (residual - 1)) ));
+    }, {VERIFY(0, 1, S[0], 3 * ( 99 * 98 * 0.5 - 3 * 0.5 * nthreads * (nthreads - 1) - 0.5 * residual * (residual - 1)) ); any_fail += fail;});
   } else {
     DUMP_SUCCESS(1);
   }
@@ -429,7 +430,7 @@ int main(void) {
           A[i] += C[i] + D[i];
         }
       }
-    }, VERIFY(0, N, A[i], 2*i+2) );
+    }, {VERIFY(0, N, A[i], 2*i+2); any_fail += fail;} );
   } else {
     DUMP_SUCCESS(1);
   }

--- a/t-unified-multiple-parallel/test.c
+++ b/t-unified-multiple-parallel/test.c
@@ -31,6 +31,7 @@
 #define PARALLEL125() { PARALLEL25() PARALLEL25() PARALLEL25() PARALLEL25() PARALLEL25() }
 
 int main(void) {
+  int any_fail = 0;
   check_offloading();
 
   double A[N], B[N], C[N], D[N], E[N];
@@ -45,7 +46,7 @@ int main(void) {
      A[i] = 0;
    }
    PARALLEL125()
-  }, VERIFY(0, 512, A[i], 125*(1+i)));
+  }, {VERIFY(0, 512, A[i], 125*(1+i)); any_fail += fail;});
 
-  return 0;
+  return any_fail > 0;
 }

--- a/t-unified-parallel/test.c
+++ b/t-unified-parallel/test.c
@@ -16,6 +16,7 @@
 #define ZERO(X) ZERO_ARRAY(N, X)
 
 int main(void) {
+  int any_fail = 0;
   check_offloading();
 
   double A[N], B[N], C[N], D[N], E[N];
@@ -40,7 +41,7 @@ int main(void) {
       int tid = omp_get_thread_num();
       A[tid] += tid;
     }
-  }, VERIFY(0, 128, A[i], i*(trial+1)));
+  }, {VERIFY(0, 128, A[i], i*(trial+1)); any_fail += fail;});
 
   //
   // Test: Execute parallel on device
@@ -53,7 +54,7 @@ int main(void) {
         B[j] = D[j] + E[j];
       }
     }
-    }, VERIFY(0, 512, B[i], (double)0));
+    }, {VERIFY(0, 512, B[i], (double)0); any_fail += fail;});
 
   //
   // Test: if clause serial execution of parallel region on target
@@ -65,7 +66,7 @@ int main(void) {
       int tid = omp_get_thread_num();
       A[tid] = tid;
     }
-  }, VERIFY(0, 128, A[i], 0));
+  }, {VERIFY(0, 128, A[i], 0); any_fail += fail;});
 
   //
   // Test: if clause serial execution of parallel region on target
@@ -77,7 +78,7 @@ int main(void) {
       int tid = omp_get_thread_num();
       A[tid] = tid;
     }
-  }, VERIFY(0, 128, A[i], 0));
+  }, {VERIFY(0, 128, A[i], 0); any_fail += fail;});
 
   //
   // Test: if clause parallel execution of parallel region on target
@@ -89,7 +90,7 @@ int main(void) {
       int tid = omp_get_thread_num();
       A[tid] = tid;
     }
-  }, VERIFY(0, 128, A[i], i));
+  }, {VERIFY(0, 128, A[i], i); any_fail += fail;});
 
   //
   // Test: proc_bind clause
@@ -116,7 +117,7 @@ int main(void) {
         B[j] += 1 + D[j] + E[j];
       }
     }
-  }, VERIFY(0, 512, B[i], 3));
+  }, {VERIFY(0, 512, B[i], 3); any_fail += fail;});
 
   //
   // Test: num_threads on parallel.
@@ -134,7 +135,7 @@ int main(void) {
         int tid = omp_get_thread_num();
         A[tid] = 99;
       }
-    }, VERIFY(0, 128, A[i], 99*(i < t)));
+    }, {VERIFY(0, 128, A[i], 99*(i < t)); any_fail += fail;});
   }
 
   //
@@ -152,7 +153,7 @@ int main(void) {
       A[0] += tmp;
     }
   A[0] += tmp;
-  }, VERIFY(0, 1, A[i], 5));
+  }, {VERIFY(0, 1, A[i], 5); any_fail += fail;});
 
   //
   // Test: private clause on parallel region.
@@ -169,7 +170,7 @@ int main(void) {
       A[0] += tmp;
     }
   A[0] += tmp;
-  }, VERIFY(0, 1, A[i], 4));
+  }, {VERIFY(0, 1, A[i], 4); any_fail += fail;});
 
   //
   // Test: firstprivate clause on parallel region.
@@ -186,7 +187,7 @@ int main(void) {
       A[0] += tmp;
     }
   A[0] += tmp;
-  }, VERIFY(0, 1, A[i], 5));
+  }, {VERIFY(0, 1, A[i], 5); any_fail += fail;});
 
   //
   // Test: shared clause on parallel region.
@@ -205,7 +206,7 @@ int main(void) {
       A[0] += tmp;
     }
   A[0] += tmp + distance;
-  }, VERIFY(0, 1, A[i], 65));
+  }, {VERIFY(0, 1, A[i], 65); any_fail += fail;});
 
   //
   // Test: sharing of array from master to parallel region.
@@ -227,7 +228,7 @@ int main(void) {
   for (int i = 0; i < 128; i++) {
     A[i] += B[i];
   }
-  }, VERIFY(0, 128, A[i], 103));
+  }, {VERIFY(0, 128, A[i], 103); any_fail += fail;});
 
   //
   // Test: array private clause on parallel region.
@@ -249,7 +250,7 @@ int main(void) {
   for (int i = 0; i < 128; i++) {
     A[i] += B[i];
   }
-  }, VERIFY(0, 128, A[i], 101));
+  }, {VERIFY(0, 128, A[i], 101); any_fail += fail;});
 
   //
   // Test: array firstprivate clause on parallel region.
@@ -271,7 +272,7 @@ int main(void) {
   for (int i = 0; i < 128; i++) {
     A[i] += B[i];
   }
-  }, VERIFY(0, 128, A[i], 111));
+  }, {VERIFY(0, 128, A[i], 111); any_fail += fail;});
 
   //
   // Test: array shared clause on parallel region.
@@ -293,7 +294,7 @@ int main(void) {
       A[0] += B[0] + distance[30];
     }
   A[0] += B[0] + distance[30];
-  }, VERIFY(0, 1, A[i], 171));
+  }, {VERIFY(0, 1, A[i], 171); any_fail += fail;});
 
   struct CITY {
     char name[128];
@@ -328,7 +329,7 @@ int main(void) {
       int tid = omp_get_thread_num();
       data.A[1+tid] += 1+tid + (int) data.city.name[1] + data.city.distance_to_nyc;
     }
-  }, VERIFY(0, 128, data.A[i], (132 + i)*(trial+1)));
+  }, {VERIFY(0, 128, data.A[i], (132 + i)*(trial+1)); any_fail += fail;});
 
   //
   // Test: sharing of struct from master to parallel region.
@@ -350,7 +351,7 @@ int main(void) {
   for (int i = 0; i < 128; i++) {
     data.A[i] += data.B[i];
   }
-  }, VERIFY(0, 128, data.A[i], 103));
+  }, {VERIFY(0, 128, data.A[i], 103); any_fail += fail;});
 
   //
   // Test: struct private clause on parallel region.
@@ -372,7 +373,7 @@ int main(void) {
   for (int i = 0; i < 128; i++) {
     data.A[i] += data.B[i];
   }
-  }, VERIFY(0, 1, data.A[i], 100));
+  }, {VERIFY(0, 1, data.A[i], 100); any_fail += fail;});
 
   //
   // Test: struct firstprivate clause on parallel region.
@@ -393,7 +394,7 @@ int main(void) {
       tmp = data.A[0];
     }
   data.A[0] += data.B[0] + tmp;
-  }, VERIFY(0, 1, data.A[i], 210));
+  }, {VERIFY(0, 1, data.A[i], 210); any_fail += fail;});
 
   //
   // Test: struct shared clause on parallel region.
@@ -415,7 +416,7 @@ int main(void) {
       A[0] += B[0] + city.distance_to_nyc;
     }
   A[0] += B[0] + city.distance_to_nyc;
-  }, VERIFY(0, 1, A[i], 171));
+  }, {VERIFY(0, 1, A[i], 171); any_fail += fail;});
 
-  return 0;
+  return any_fail > 0;
 }

--- a/t-unified-runtime-calls/test.c
+++ b/t-unified-runtime-calls/test.c
@@ -23,6 +23,7 @@
 //
 
 int main(void) {
+  int any_fail = 0;
   // CHECK: Able to use offloading!
   check_offloading();
 
@@ -43,7 +44,7 @@ int main(void) {
         A[0] += omp_get_num_threads();  // 128
       }
     }
-  }, VERIFY(0, 1, A[i], 129));
+  }, {VERIFY(0, 1, A[i], 129); any_fail += fail;});
 
   //
   // Test: omp_get_max_threads() (depends on device type)
@@ -59,7 +60,7 @@ int main(void) {
 	    A[1] = omp_get_num_threads();
 	  }
       }
-    }, if (!omp_is_initial_device()) VERIFY(0, 1, A[i], A[1] + 1));
+    }, if (!omp_is_initial_device()) {VERIFY(0, 1, A[i], A[1] + 1); any_fail += fail;});
   //
   // Test: omp_get_num_procs()
   //
@@ -74,7 +75,7 @@ int main(void) {
         A[1] = 2*omp_get_num_threads();
       }
     }
-  }, VERIFY(0, 1, A[i], A[1]));
+  }, {VERIFY(0, 1, A[i], A[1]); any_fail += fail;});
   
   //
   // Test: omp_in_parallel()
@@ -83,24 +84,24 @@ int main(void) {
   TEST({
   _Pragma("omp distribute dist_schedule(static,1)")
     for (int i = 0; i < 1; ++i) {
-      _Pragma("atomic write")
+      _Pragma("omp atomic write")
         A[0] = omp_in_parallel();  // 0
     }
    // Serialized parallel
   _Pragma("omp parallel num_threads(32) if (A[0] == 1)")
     {
-      _Pragma("atomic update")
+      _Pragma("omp atomic update")
         A[0] += omp_in_parallel();  // 0
     }
     // Parallel execution
   _Pragma("omp parallel num_threads(32) if (A[0] == 0)")
     {
       if (omp_get_thread_num() == 0) {
-        _Pragma("atomic update")
+        _Pragma("omp atomic update")
           A[0] += omp_in_parallel();  // 1
       }
     }
-  }, VERIFY(0, 1, A[i], 1));
+  }, {VERIFY(0, 1, A[i], 1); any_fail += fail;});
 
   //
   // Test: omp_set/get_dynamic()
@@ -124,7 +125,7 @@ int main(void) {
   _Pragma("omp distribute dist_schedule(static,1)")
   for (int i = 0; i < 1; ++i)
     A[0] += omp_get_dynamic();  // 1
-  }, VERIFY(0, 1, A[i], 3));
+  }, {VERIFY(0, 1, A[i], 3); any_fail += fail;});
 
   //
   // Test: omp_get_cancellation()
@@ -140,7 +141,7 @@ int main(void) {
         A[0] += omp_get_cancellation();  // 0
       }
     }
-  }, VERIFY(0, 1, A[i], 0));
+  }, {VERIFY(0, 1, A[i], 0); any_fail += fail;});
 
   //
   // Test: omp_set/get_nested().  Not used on the device currently.
@@ -162,7 +163,7 @@ int main(void) {
     }
   _Pragma("omp parallel if(0)")
     A[0] += omp_get_nested();  // 0
-  }, VERIFY(0, 1, A[i], 0));
+  }, {VERIFY(0, 1, A[i], 0); any_fail += fail;});
 
   //
   // Test: omp_set/get_schedule().
@@ -218,7 +219,7 @@ int main(void) {
     _Pragma("omp parallel if(0)")
       omp_get_schedule(&t, &chunk_size);  // should read 1, 10;
     A[0] += t + chunk_size;
-  }, VERIFY(0, 1, A[i], result));
+  }, {VERIFY(0, 1, A[i], result); any_fail += fail;});
 
   //
   // Test: omp_get_thread_limit()
@@ -235,7 +236,7 @@ int main(void) {
         A[1] = 2*omp_get_num_threads();
       }
     }
-  }, VERIFY(0, 1, A[i], A[1]));
+  }, {VERIFY(0, 1, A[i], A[1]); any_fail += fail;});
 
   //
   // Test: omp_set/get_max_active_levels()
@@ -254,7 +255,7 @@ int main(void) {
         A[0] += omp_get_max_active_levels();  // 1
       }
     }
-  }, VERIFY(0, 1, A[i], 2));
+  }, {VERIFY(0, 1, A[i], 2); any_fail += fail;});
 
   //
   // Test: omp_get_level()
@@ -270,7 +271,7 @@ int main(void) {
         A[0] += omp_get_level();  // 1
       }
     }
-  }, VERIFY(0, 1, A[i], 1));
+  }, {VERIFY(0, 1, A[i], 1); any_fail += fail;});
 
   //
   // Test: omp_get_ancestor_thread_num()
@@ -285,7 +286,7 @@ int main(void) {
 	  A[0] += omp_get_ancestor_thread_num(0) + omp_get_ancestor_thread_num(1);  // 0 + 18
 	}
       }
-    }, VERIFY(0, 1, A[i], 0));
+    }, {VERIFY(0, 1, A[i], 0); any_fail += fail;});
 
   //
   // Test: omp_get_team_size()
@@ -300,7 +301,7 @@ int main(void) {
         A[0] += omp_get_team_size(0) + omp_get_team_size(1);  // 1 + 19
       }
     }
-    }, if (!omp_is_initial_device()) VERIFY(0, 1, A[i], 22)); // TODO: fix host execution
+    }, if (!omp_is_initial_device()) {VERIFY(0, 1, A[i], 22); any_fail += fail;}); // TODO: fix host execution
   //
   // Test: omp_get_active_level()
   //
@@ -317,7 +318,7 @@ int main(void) {
           A[0] += omp_get_active_level();  // 1
       }
     }
-  }, VERIFY(0, 1, A[i], 1));
+  }, {VERIFY(0, 1, A[i], 1); any_fail += fail;});
 
   //
   // Test: omp_in_final()
@@ -332,7 +333,7 @@ int main(void) {
 	  A[0] += omp_in_final();  // 1  always returns true.
 	}
       }
-    }, VERIFY(0, 1, A[i], omp_is_initial_device() ? 0 : 2));
+    }, {VERIFY(0, 1, A[i], omp_is_initial_device() ? 0 : 2); any_fail += fail;});
 
   //
   // Test: omp_get_proc_bind()
@@ -347,7 +348,7 @@ int main(void) {
         A[0] += omp_get_proc_bind();  // 1  always returns omp_proc_bind_true.
       }
     }
-    },  VERIFY(0, 1, A[i], omp_is_initial_device() ? 0 : 2));
+    },  {VERIFY(0, 1, A[i], omp_is_initial_device() ? 0 : 2); any_fail += fail;});
 
 #if 0
   //
@@ -366,7 +367,7 @@ int main(void) {
       int *place_nums;
       omp_get_partition_place_nums(place_nums);
     }
-  }, VERIFY(0, 1, A[i], 0));
+  }, {VERIFY(0, 1, A[i], 0); any_fail += fail;});
 #endif
 
   //
@@ -386,7 +387,7 @@ int main(void) {
         A[0] += omp_get_default_device();  // 0  always returns 0.
       }
     }
-  }, VERIFY(0, 1, A[i], 0));
+  }, {VERIFY(0, 1, A[i], 0); any_fail += fail;});
 
   //
   // Test: omp_get_num_devices(). Undefined on the target.
@@ -401,7 +402,7 @@ int main(void) {
         A[1] = omp_get_num_devices();
       }
     }
-  }, VERIFY(0, 1, A[i], A[i] - A[1]));
+  }, {VERIFY(0, 1, A[i], A[i] - A[1]); any_fail += fail;});
 
   //
   // Test: omp_get_num_teams(), omp_get_team_num()
@@ -418,7 +419,7 @@ int main(void) {
         A[0] += omp_get_team_num();   // 0
       }
     }
-  }, VERIFY(0, 1, A[i], 2));
+  }, {VERIFY(0, 1, A[i], 2); any_fail += fail;});
 
   //
   // Test: omp_is_initial_device()
@@ -434,7 +435,7 @@ int main(void) {
         A[0] += omp_is_initial_device();  // 0
       }
     }
-    }, VERIFY(0, 1, A[i], omp_is_initial_device() ? A[1] - A[1] : 2.0));
+    }, {VERIFY(0, 1, A[i], omp_is_initial_device() ? A[1] - A[1] : 2.0); any_fail += fail;});
 
   return 0;
 
@@ -453,7 +454,7 @@ int main(void) {
         A[0] -= omp_get_initial_device();
       }
     }
-  }, VERIFY(0, 1, A[i], 0));
+  }, {VERIFY(0, 1, A[i], 0); any_fail += fail;});
 #endif
 
 #if 0
@@ -471,7 +472,7 @@ int main(void) {
         A[0] -= omp_get_max_task_priority();
       }
     }
-  }, VERIFY(0, 1, A[i], 0));
+  }, {VERIFY(0, 1, A[i], 0); any_fail += fail;});
 #endif
 
 
@@ -489,7 +490,7 @@ int main(void) {
       start = omp_get_wtime();
       end = omp_get_wtime();
     }
-  }, VERIFY(0, 1, A[i], 0));
+  }, {VERIFY(0, 1, A[i], 0); any_fail += fail;});
 
-  return 0;
+  return any_fail > 0;
 }

--- a/t-unified-target-parallel-for-simd/test.c
+++ b/t-unified-target-parallel-for-simd/test.c
@@ -33,6 +33,7 @@
 //
 
 int main(void) {
+  int any_fail = 0;
   check_offloading();
 
   double A[N], B[N], C[N], D[N], E[N];
@@ -76,7 +77,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR2(
     {
@@ -96,7 +97,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR3(
     {
@@ -116,7 +117,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR4(
     {
@@ -136,7 +137,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR5(
     {
@@ -156,7 +157,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR6(
     {
@@ -176,7 +177,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR7(
     {
@@ -196,7 +197,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR8(
     {
@@ -216,7 +217,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR9(
     {
@@ -236,7 +237,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
   }
   DUMP_SUCCESS9()
 
@@ -263,7 +264,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR2(
     {
@@ -283,7 +284,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR3(
     {
@@ -303,7 +304,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR4(
     {
@@ -323,7 +324,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR5(
     {
@@ -343,7 +344,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR6(
     {
@@ -363,7 +364,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR7(
     {
@@ -383,7 +384,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR8(
     {
@@ -403,7 +404,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR9(
     {
@@ -423,7 +424,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
   }
   DUMP_SUCCESS9()
 
@@ -450,7 +451,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR2(
     {
@@ -470,7 +471,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR3(
     {
@@ -490,7 +491,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR4(
     {
@@ -510,7 +511,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR5(
     {
@@ -530,7 +531,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR6(
     {
@@ -550,7 +551,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR7(
     {
@@ -570,7 +571,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR8(
     {
@@ -590,7 +591,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR9(
     {
@@ -610,7 +611,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
   }
   DUMP_SUCCESS9()
 
@@ -645,7 +646,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], 6 + N/2*(N+1)))
+    {VERIFY(0, 1, S[0], 6 + N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR2(
       double p = 2; \
@@ -668,7 +669,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], 6 + N/2*(N+1)))
+    {VERIFY(0, 1, S[0], 6 + N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR3(
       double p = 2; \
@@ -691,7 +692,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], 6 + N/2*(N+1)))
+    {VERIFY(0, 1, S[0], 6 + N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR4(
       double p = 2; \
@@ -714,7 +715,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], 6 + N/2*(N+1)))
+    {VERIFY(0, 1, S[0], 6 + N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR5(
       double p = 2; \
@@ -737,7 +738,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], 6 + N/2*(N+1)))
+    {VERIFY(0, 1, S[0], 6 + N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR6(
       double p = 2; \
@@ -760,7 +761,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], 6 + N/2*(N+1)))
+    {VERIFY(0, 1, S[0], 6 + N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR7(
       double p = 2; \
@@ -783,7 +784,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], 6 + N/2*(N+1)))
+    {VERIFY(0, 1, S[0], 6 + N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR8(
       double p = 2; \
@@ -806,7 +807,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], 6 + N/2*(N+1)))
+    {VERIFY(0, 1, S[0], 6 + N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR9(
       double p = 2; \
@@ -829,7 +830,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], 6 + N/2*(N+1)))
+    {VERIFY(0, 1, S[0], 6 + N/2*(N+1)); any_fail += fail;})
   }
   DUMP_SUCCESS9()
 
@@ -864,7 +865,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR2(
       double p = -4; \
@@ -889,7 +890,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR3(
       double p = -4; \
@@ -914,7 +915,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR4(
       double p = -4; \
@@ -939,7 +940,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR5(
       double p = -4; \
@@ -964,7 +965,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR6(
       double p = -4; \
@@ -989,7 +990,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR7(
       double p = -4; \
@@ -1014,7 +1015,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR8(
       double p = -4; \
@@ -1039,7 +1040,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
 
     TARGET_PARALLEL_FOR9(
       double p = -4; \
@@ -1064,7 +1065,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail;})
   }
   DUMP_SUCCESS9()
 
@@ -1100,7 +1101,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N+1+ N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N+1+ N/2*(N+1)); any_fail += fail;})
   }
 
   FIXME: private of non-scalar does not work.
@@ -1133,7 +1134,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], 6 + SUMS * (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], 6 + SUMS * (N/2*(N+1))); any_fail += fail;})
   }
 
   FIXME: private of non-scalar does not work.
@@ -1168,7 +1169,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))); any_fail += fail;})
   }
 #endif
 
@@ -1200,7 +1201,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], (N/2*(N+1))); any_fail += fail;})
 
     TARGET_PARALLEL_FOR2(
       S[0] = 0; \
@@ -1222,7 +1223,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], (N/2*(N+1))); any_fail += fail;})
 
     TARGET_PARALLEL_FOR3(
       S[0] = 0; \
@@ -1244,7 +1245,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], (N/2*(N+1))); any_fail += fail;})
 
     TARGET_PARALLEL_FOR4(
       S[0] = 0; \
@@ -1266,7 +1267,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], (N/2*(N+1))); any_fail += fail;})
 
     TARGET_PARALLEL_FOR5(
       S[0] = 0; \
@@ -1288,7 +1289,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], (N/2*(N+1))); any_fail += fail;})
 
     TARGET_PARALLEL_FOR6(
       S[0] = 0; \
@@ -1310,7 +1311,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], (N/2*(N+1))); any_fail += fail;})
 
     TARGET_PARALLEL_FOR7(
       S[0] = 0; \
@@ -1332,7 +1333,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], (N/2*(N+1))); any_fail += fail;})
 
     TARGET_PARALLEL_FOR8(
       S[0] = 0; \
@@ -1354,7 +1355,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], (N/2*(N+1))); any_fail += fail;})
 
     TARGET_PARALLEL_FOR9(
       S[0] = 0; \
@@ -1376,7 +1377,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], (N/2*(N+1))); any_fail += fail;})
   }
   DUMP_SUCCESS9()
  
@@ -1405,7 +1406,7 @@ int main(void) {
       }
       S[0] = tmp;
     },
-    VERIFY(0, 1, S[0], (32*32 + 64*32) ))
+    {VERIFY(0, 1, S[0], (32*32 + 64*32) ); any_fail += fail;})
 
     TARGET_PARALLEL_FOR2(
       S[0] = 0; \
@@ -1424,7 +1425,7 @@ int main(void) {
       }
       S[0] = tmp;
     },
-    VERIFY(0, 1, S[0], (32*32 + 64*32) ))
+    {VERIFY(0, 1, S[0], (32*32 + 64*32) ); any_fail += fail;})
 
     TARGET_PARALLEL_FOR7(
       S[0] = 0; \
@@ -1443,11 +1444,10 @@ int main(void) {
       }
       S[0] = tmp;
     },
-    VERIFY(0, 1, S[0], (32*32 + 64*32) ))
+    {VERIFY(0, 1, S[0], (32*32 + 64*32) ); any_fail += fail;})
   } else {
     DUMP_SUCCESS(3);
   }
 
-  return 0;
+  return any_fail > 0;
 }
-

--- a/t-unified-target-parallel-for/test.c
+++ b/t-unified-target-parallel-for/test.c
@@ -33,6 +33,7 @@
 //
 
 int main(void) {
+  int any_fail = 0;
   check_offloading();
 
   double A[N], B[N], C[N], D[N], E[N];
@@ -76,7 +77,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR2(
     {
@@ -96,7 +97,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR3(
     {
@@ -116,7 +117,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR4(
     {
@@ -136,7 +137,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR5(
     {
@@ -156,7 +157,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR6(
     {
@@ -176,7 +177,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR7(
     {
@@ -196,7 +197,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR8(
     {
@@ -216,7 +217,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR9(
     {
@@ -236,7 +237,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
   }
   DUMP_SUCCESS9()
 
@@ -263,7 +264,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR2(
     {
@@ -283,7 +284,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR3(
     {
@@ -303,7 +304,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR4(
     {
@@ -323,7 +324,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR5(
     {
@@ -343,7 +344,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR6(
     {
@@ -363,7 +364,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR7(
     {
@@ -383,7 +384,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR8(
     {
@@ -403,7 +404,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR9(
     {
@@ -423,7 +424,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
   }
   DUMP_SUCCESS9()
 
@@ -450,7 +451,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR2(
     {
@@ -470,7 +471,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR3(
     {
@@ -490,7 +491,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR4(
     {
@@ -510,7 +511,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR5(
     {
@@ -530,7 +531,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR6(
     {
@@ -550,7 +551,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR7(
     {
@@ -570,7 +571,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR8(
     {
@@ -590,7 +591,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR9(
     {
@@ -610,7 +611,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
   }
   DUMP_SUCCESS9()
 
@@ -645,7 +646,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], 6 + N/2*(N+1)))
+    {VERIFY(0, 1, S[0], 6 + N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR2(
       double p = 2; \
@@ -668,7 +669,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], 6 + N/2*(N+1)))
+    {VERIFY(0, 1, S[0], 6 + N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR3(
       double p = 2; \
@@ -691,7 +692,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], 6 + N/2*(N+1)))
+    {VERIFY(0, 1, S[0], 6 + N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR4(
       double p = 2; \
@@ -714,7 +715,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], 6 + N/2*(N+1)))
+    {VERIFY(0, 1, S[0], 6 + N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR5(
       double p = 2; \
@@ -737,7 +738,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], 6 + N/2*(N+1)))
+    {VERIFY(0, 1, S[0], 6 + N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR6(
       double p = 2; \
@@ -760,7 +761,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], 6 + N/2*(N+1)))
+    {VERIFY(0, 1, S[0], 6 + N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR7(
       double p = 2; \
@@ -783,7 +784,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], 6 + N/2*(N+1)))
+    {VERIFY(0, 1, S[0], 6 + N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR8(
       double p = 2; \
@@ -806,7 +807,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], 6 + N/2*(N+1)))
+    {VERIFY(0, 1, S[0], 6 + N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR9(
       double p = 2; \
@@ -829,7 +830,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], 6 + N/2*(N+1)))
+    {VERIFY(0, 1, S[0], 6 + N/2*(N+1)); any_fail += fail; })
   }
   DUMP_SUCCESS9()
 
@@ -864,7 +865,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR2(
       double p = -4; \
@@ -889,7 +890,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR3(
       double p = -4; \
@@ -914,7 +915,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR4(
       double p = -4; \
@@ -939,7 +940,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR5(
       double p = -4; \
@@ -964,7 +965,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR6(
       double p = -4; \
@@ -989,7 +990,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR7(
       double p = -4; \
@@ -1014,7 +1015,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR8(
       double p = -4; \
@@ -1039,7 +1040,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR9(
       double p = -4; \
@@ -1064,7 +1065,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
   }
   DUMP_SUCCESS9()
 
@@ -1102,7 +1103,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], N+1+ N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N+1+ N/2*(N+1)); any_fail += fail; })
   }
 
   FIXME: private of non-scalar does not work.
@@ -1135,7 +1136,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], 6 + SUMS * (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], 6 + SUMS * (N/2*(N+1))); any_fail += fail; })
   }
 
   FIXME: private of non-scalar does not work.
@@ -1170,7 +1171,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))); any_fail += fail; })
   }
 #endif
 
@@ -1202,7 +1203,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], (N/2*(N+1))); any_fail += fail; })
 
     TARGET_PARALLEL_FOR2(
       S[0] = 0; \
@@ -1224,7 +1225,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], (N/2*(N+1))); any_fail += fail; })
 
     TARGET_PARALLEL_FOR3(
       S[0] = 0; \
@@ -1246,7 +1247,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], (N/2*(N+1))); any_fail += fail; })
 
     TARGET_PARALLEL_FOR4(
       S[0] = 0; \
@@ -1268,7 +1269,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], (N/2*(N+1))); any_fail += fail; })
 
     TARGET_PARALLEL_FOR5(
       S[0] = 0; \
@@ -1290,7 +1291,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], (N/2*(N+1))); any_fail += fail; })
 
     TARGET_PARALLEL_FOR6(
       S[0] = 0; \
@@ -1312,7 +1313,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], (N/2*(N+1))); any_fail += fail; })
 
     TARGET_PARALLEL_FOR7(
       S[0] = 0; \
@@ -1334,7 +1335,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], (N/2*(N+1))); any_fail += fail; })
 
     TARGET_PARALLEL_FOR8(
       S[0] = 0; \
@@ -1356,7 +1357,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], (N/2*(N+1))); any_fail += fail; })
 
     TARGET_PARALLEL_FOR9(
       S[0] = 0; \
@@ -1378,7 +1379,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], (N/2*(N+1))); any_fail += fail; })
   }
   DUMP_SUCCESS9()
 
@@ -1400,7 +1401,7 @@ int main(void) {
     ,
     {
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR2(
       S[0] = 0; \
@@ -1412,7 +1413,7 @@ int main(void) {
     ,
     {
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR3(
       S[0] = 0; \
@@ -1424,7 +1425,7 @@ int main(void) {
     ,
     {
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR4(
       S[0] = 0; \
@@ -1436,7 +1437,7 @@ int main(void) {
     ,
     {
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR5(
       S[0] = 0; \
@@ -1448,7 +1449,7 @@ int main(void) {
     ,
     {
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR6(
       S[0] = 0; \
@@ -1460,7 +1461,7 @@ int main(void) {
     ,
     {
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR7(
       S[0] = 0; \
@@ -1472,7 +1473,7 @@ int main(void) {
     ,
     {
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR8(
       S[0] = 0; \
@@ -1484,7 +1485,7 @@ int main(void) {
     ,
     {
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
 
     TARGET_PARALLEL_FOR9(
       S[0] = 0; \
@@ -1496,7 +1497,7 @@ int main(void) {
     ,
     {
     },
-    VERIFY(0, 1, S[0], N/2*(N+1)))
+    {VERIFY(0, 1, S[0], N/2*(N+1)); any_fail += fail; })
   }
   DUMP_SUCCESS9()
 
@@ -1525,7 +1526,7 @@ int main(void) {
       }
       S[0] = tmp;
     },
-    VERIFY(0, 1, S[0], (32*32 + 64*32) ))
+    {VERIFY(0, 1, S[0], (32*32 + 64*32) ); any_fail += fail; })
 
     TARGET_PARALLEL_FOR2(
       S[0] = 0; \
@@ -1544,7 +1545,7 @@ int main(void) {
       }
       S[0] = tmp;
     },
-    VERIFY(0, 1, S[0], (32*32 + 64*32) ))
+    {VERIFY(0, 1, S[0], (32*32 + 64*32) ); any_fail += fail; })
 
     TARGET_PARALLEL_FOR7(
       S[0] = 0; \
@@ -1563,11 +1564,11 @@ int main(void) {
       }
       S[0] = tmp;
     },
-    VERIFY(0, 1, S[0], (32*32 + 64*32) ))
+    {VERIFY(0, 1, S[0], (32*32 + 64*32) ); any_fail += fail; })
   } else {
     DUMP_SUCCESS(3);
   }
 
-  return 0;
+  return any_fail > 0;
 }
 

--- a/t-unified-target-parallel/test.c
+++ b/t-unified-target-parallel/test.c
@@ -17,6 +17,7 @@
 #define ZERO(X) ZERO_ARRAY(N, X)
 
 int main(void) {
+  int any_fail = 0;
   check_offloading();
 
   double A[N], B[N], C[N], D[N], E[N];
@@ -38,7 +39,7 @@ int main(void) {
   TESTD("omp target parallel num_threads(max_threads)", {
     int tid = omp_get_thread_num();
     A[tid] += tid;
-  }, VERIFY(0,  max_threads, A[i], i*(trial+1)));
+  }, {VERIFY(0,  max_threads, A[i], i*(trial+1)); any_fail += fail;});
 
   //
   // Test: Execute parallel on device
@@ -48,7 +49,7 @@ int main(void) {
       for (int j = i; j < i + 4; j++) {
         B[j] = D[j] + E[j];
       }
-    }, VERIFY(0, max_threads*4, B[i], (double)0));
+    }, {VERIFY(0, max_threads*4, B[i], (double)0); any_fail += fail;});
 
   //
   // Test: if clause serial execution of parallel region on host
@@ -57,7 +58,7 @@ int main(void) {
   TESTD("omp target parallel num_threads(max_threads) if(0)", {
       int tid = omp_get_thread_num();
       A[tid] = tid;
-  }, VERIFY(0, max_threads, A[i], 0));
+  }, {VERIFY(0, max_threads, A[i], 0); any_fail += fail;});
 
   //
   // Test: if clause parallel execution of parallel region on device
@@ -66,7 +67,7 @@ int main(void) {
   TESTD("omp target parallel num_threads(max_threads) if(A[0] == 0)", {
       int tid = omp_get_thread_num();
       A[tid] = tid + omp_is_initial_device();
-  }, VERIFY(0, max_threads, A[i], i + cpuExec));
+  }, {VERIFY(0, max_threads, A[i], i + cpuExec); any_fail += fail;});
 
   //
   // Test: if clause serial execution of parallel region on device
@@ -75,7 +76,7 @@ int main(void) {
   TESTD("omp target parallel num_threads(max_threads) if(parallel: 0)", {
       int tid = omp_get_thread_num();
       A[tid] = !omp_is_initial_device();
-  }, VERIFY(0, max_threads, A[i], i == 0 ? 1 - cpuExec : 0));
+  }, {VERIFY(0, max_threads, A[i], i == 0 ? 1 - cpuExec : 0); any_fail += fail;});
 
 
   //
@@ -85,7 +86,7 @@ int main(void) {
   TESTD("omp target parallel num_threads(max_threads) if(target: 0) if(parallel: A[0] == 0)", {
       int tid = omp_get_thread_num();
       A[tid] = tid + omp_is_initial_device();
-  }, VERIFY(0, /* bound to */ cpu_threads, A[i], i+1));
+  }, {VERIFY(0, /* bound to */ cpu_threads, A[i], i+1); any_fail += fail;});
 
 
   //
@@ -95,7 +96,7 @@ int main(void) {
   TESTD("omp target parallel if(parallel: A[0] > 0)", {
       int tid = omp_get_thread_num();
       A[tid] = omp_get_num_threads();
-  }, VERIFY(0, 1, A[0], 1));
+  }, {VERIFY(0, 1, A[0], 1); any_fail += fail;});
 
   //
   // Test: if clause parallel execution of parallel region on device without num_threads clause
@@ -110,7 +111,7 @@ int main(void) {
   TESTD("omp target parallel if(parallel: A[0] == 0)", {
       int tid = omp_get_thread_num();
       A[tid] = omp_get_num_threads();
-  }, VERIFY(0, 1, A[0], B[0]));
+  }, {VERIFY(0, 1, A[0], B[0]); any_fail += fail;});
 
   //
   // Test: if clause parallel execution of parallel region on device with num_threads clause
@@ -119,7 +120,7 @@ int main(void) {
   TESTD("omp target parallel num_threads(1) if(parallel: A[0] == 0)", {
       int tid = omp_get_thread_num();
       A[tid] = omp_get_num_threads();
-  }, VERIFY(0, 1, A[0], 1));
+  }, {VERIFY(0, 1, A[0], 1); any_fail += fail;});
 
   //
   // Test: proc_bind clause
@@ -129,19 +130,19 @@ int main(void) {
       for (int j = i; j < i + 4; j++) {
         B[j] = 1 + D[j] + E[j];
       }
-  }, VERIFY(0, max_threads*4, B[i], 1));
+  }, {VERIFY(0, max_threads*4, B[i], 1); any_fail += fail;});
   TESTD("omp target parallel num_threads(max_threads) proc_bind(close)", {
       int i = omp_get_thread_num()*4;
       for (int j = i; j < i + 4; j++) {
         B[j] = 1 + D[j] + E[j];
       }
-  }, VERIFY(0, max_threads*4, B[i], 1));
+  }, {VERIFY(0, max_threads*4, B[i], 1); any_fail += fail;});
   TESTD("omp target parallel num_threads(max_threads) proc_bind(spread)", {
       int i = omp_get_thread_num()*4;
       for (int j = i; j < i + 4; j++) {
         B[j] = 1 + D[j] + E[j];
       }
-  }, VERIFY(0, max_threads*4, B[i], 1));
+  }, {VERIFY(0, max_threads*4, B[i], 1); any_fail += fail;});
 
   //
   // Test: num_threads on parallel.
@@ -152,7 +153,7 @@ int main(void) {
     TESTD("omp target parallel num_threads(threads[0])", {
         int tid = omp_get_thread_num();
         A[tid] = 99;
-    }, VERIFY(0, 128, A[i], 99*(i < t)));
+    }, {VERIFY(0, 128, A[i], 99*(i < t)); any_fail += fail;});
   }
   DUMP_SUCCESS(gpu_threads-max_threads);
 
@@ -166,7 +167,7 @@ int main(void) {
     TESTD("omp target parallel map(tofrom: tmp) num_threads(1)", {
         tmp = 2;
         A[0] += tmp;
-    }, VERIFY(0, 1, A[i]+tmp, (1+trial)*2+1+2));
+    }, {VERIFY(0, 1, A[i]+tmp, (1+trial)*2+1+2); any_fail += fail;});
   }
 
   //
@@ -181,7 +182,7 @@ int main(void) {
         p[0] = 2;
         q = 0;
         A[0] += p[0];
-    }, VERIFY(0, 1, A[i]+p[0]+q, (1+trial)*2+2+99));
+    }, {VERIFY(0, 1, A[i]+p[0]+q, (1+trial)*2+2+99); any_fail += fail;});
   }
 
   //
@@ -196,7 +197,7 @@ int main(void) {
         A[0] += p[0] + q;
         p[0] = 2;
         q = 0;
-    }, VERIFY(0, 1, A[i]+p[0]+q, (1+trial)*(99+5)+5+5+99));
+    }, {VERIFY(0, 1, A[i]+p[0]+q, (1+trial)*(99+5)+5+5+99); any_fail += fail;});
   }
 
 #if 0
@@ -219,9 +220,9 @@ int main(void) {
           A[0] += p[0] + q;
         _Pragma("omp barrier")
         p[0] = 1; q = -100;
-    }, VERIFY(0, 1, A[i]+p[0]+q, (1+trial)*(99+2)+5+-7));
+    }, {VERIFY(0, 1, A[i]+p[0]+q, (1+trial)*(99+2)+5+-7); any_fail += fail;});
   }
 #endif
 
-  return 0;
+  return any_fail > 0;
 }

--- a/t-unified-target-teams/test.c
+++ b/t-unified-target-teams/test.c
@@ -18,6 +18,7 @@
 #define ZERO(X) ZERO_ARRAY(N, X)
 
 int main(void) {
+  int any_fail = 0;
   check_offloading();
 
   double A[N], B[N], C[N], D[N], E[N];
@@ -48,6 +49,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: device clause
@@ -69,6 +71,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: map clause
@@ -90,6 +93,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: num_teams and omp_get_team_num()
@@ -109,6 +113,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: thread_limit and omp_get_thread_num()
@@ -131,6 +136,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: if statement in teams region
@@ -165,6 +171,7 @@ int main(void) {
   }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   /* // */
   /* // Test: num_teams and thread_limit by simulating a distribute pragma */
@@ -206,6 +213,7 @@ int main(void) {
   /* } */
   /* if(fail) printf("Failed\n"); */
   /* else printf("Succeeded\n"); */
+  /* any_fail += fail; */
 
   //
   // Test: private
@@ -229,6 +237,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: firstprivate
@@ -252,6 +261,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
   
-  return 0;
+  return any_fail > 0;
 }

--- a/xt-orphaned-directives/main.cpp
+++ b/xt-orphaned-directives/main.cpp
@@ -44,6 +44,7 @@ void tadd_dpf1(T *a, T *b, T *c, int n, int sch) {
 #pragma omp end declare target
 
 int main() {
+  int any_fail = 0;
   check_offloading();
 
   int cpuExec = 0;
@@ -224,9 +225,11 @@ int main() {
       }
     }
 
-    if (OUT + num_tests != EXPECTED[e++])
+    if (OUT + num_tests != EXPECTED[e++]) {
       printf ("Failed test with num_threads = %d, OUT + num_tests = %ld\n",
               t, OUT + num_tests);
+      any_fail++;
+    }
     else
       printf ("Succeeded\n");
   }
@@ -250,9 +253,11 @@ int main() {
         }
     }
 
-    if (OUT + num_tests != EXPECTED[e++])
+    if (OUT + num_tests != EXPECTED[e++]) {
       printf ("Failed test with num_threads = %d, OUT + num_tests = %ld\n",
               t, OUT + num_tests);
+      any_fail++;
+    }
     else
       printf ("Succeeded\n");
   }
@@ -269,11 +274,13 @@ int main() {
             N, Ad, Bd, Cd, &OUT, &num_tests);
   }
 
-  if (OUT + num_tests != 1)
+  if (OUT + num_tests != 1) {
     printf ("Failed test with OUT + num_tests = %ld\n",
             OUT + num_tests);
+    any_fail++;
+  }
   else
     printf ("Succeeded\n");
 
-  return OUT + num_tests != 1;
+  return any_fail > 0;
 }


### PR DESCRIPTION
This add some more non-zero exit codes on fail (but there are more). Additionally, it adds a missing 'omp' to 'omp atomic' in t-unified-runtime-calls and t-runtime-calls and removes a '#pragma' from an argument passed indirectly to _Pragma in t-barrier and t-unified-barrier.

_Updates 16 files – but there are still 87 files with 'return 0'  (however, some main function might lack a return statement or use a different syntax for 0  – on the other hand, some 'return 0' might be okay and only used in successful cases.)_

@doru1004 – please review those as well. Thanks for your previous reviews!