### PR TITLE
More exit status fail fixes

### DIFF
--- a/t-defaultmap/test.cpp
+++ b/t-defaultmap/test.cpp
@@ -2,19 +2,22 @@
 #include <omp.h>
 
 #define V(x,y) \
-  if ((x) != (y))\
+  if ((x) != (y)) {\
     printf("Error %d != %d\n", (x), (y));\
-  else\
+    fail = 1; \
+  } else\
     printf("Success!\n");
 #define VPTR(x,y) \
-  if ((x) != (y))\
+  if ((x) != (y)) {\
     printf("Error %p != %p\n", (x), (y));\
-  else\
+    fail = 1; \
+  } else\
     printf("Success!\n");
 
 int A;
 
 int main(void) {
+  int fail = 0;
   int Old = 1;
   int New = Old + 1;
   
@@ -44,5 +47,5 @@ int main(void) {
   VPTR(D, NewPtr);
   VPTR(E, NewPtr);
   
-  return 0;
+  return fail;
 }

--- a/t-distribute-simd-dist-clauses/test.c
+++ b/t-distribute-simd-dist-clauses/test.c
@@ -451,6 +451,6 @@ int main(void) {
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
 
-  return 0;
+  return fail;
 }
 

--- a/t-dpfs-dist-clauses/test.c
+++ b/t-dpfs-dist-clauses/test.c
@@ -454,6 +454,6 @@ int main(void) {
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
 
-  return 0;
+  return fail;
 }
 

--- a/t-reduction/test.c
+++ b/t-reduction/test.c
@@ -283,6 +283,7 @@ INIT1 + INIT2 + \
 }
 
 int main(void) {
+  int any_fail = 0;
   check_offloading();
 
   char Ac[N], Bc[N], Cc[N], Dc[N], Ec[N];
@@ -334,7 +335,7 @@ int main(void) {
         }
       }
       REDUCTION_FINAL();
-    }, VERIFY(0, 6, OUT[i], (trial+1) * EXPECTED[i]));
+    }, {VERIFY(0, 6, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail; });
   }
   DUMP_SUCCESS(gpu_threads-max_threads);
 
@@ -365,7 +366,7 @@ int main(void) {
         }
       }
       REDUCTION_FINAL();
-    }, VERIFY(0, 6, OUT[i], (trial+1) * 2*EXPECTED[i]));
+    }, {VERIFY(0, 6, OUT[i], (trial+1) * 2*EXPECTED[i]); any_fail += fail; });
   }
 
   //
@@ -385,7 +386,7 @@ int main(void) {
     {
       REDUCTION_FINAL();
     },
-    VERIFY(0, 6, OUT[i], (trial+1) * SUMS * EXPECTED[i]))
+    {VERIFY(0, 6, OUT[i], (trial+1) * SUMS * EXPECTED[i]); any_fail += fail; })
   }
   DUMP_SUCCESS(gpu_threads-max_threads);
 
@@ -410,7 +411,7 @@ int main(void) {
         }
         _Pragma("omp barrier");
       },
-      VERIFY(0, 6, OUT[i], (trial+1) * SUMS * EXPECTED[i]))
+      {VERIFY(0, 6, OUT[i], (trial+1) * SUMS * EXPECTED[i]); any_fail += fail; })
     }
   } else {
     //
@@ -440,7 +441,7 @@ int main(void) {
       R1 += All[1000] + (Bll[1000] + Cll[1000]);
     }
     OUT[0] = R1;
-  }, VERIFY(0, 1, OUT[0], (5ll << 32)));
+  }, {VERIFY(0, 1, OUT[0], (5ll << 32)); any_fail += fail; });
 
   //
   // Test: reduction on parallel sections.
@@ -461,7 +462,7 @@ int main(void) {
       R1 += All[1000] + (Bll[1000] + Cll[1000]);
     }
     OUT[0] = R1;
-  }, VERIFY(0, 1, OUT[0], (5ll << 32)));
+  }, {VERIFY(0, 1, OUT[0], (5ll << 32)); any_fail += fail; });
 
   //
   // Test: reduction on distribute parallel for.
@@ -480,8 +481,8 @@ int main(void) {
       unsigned tm = omp_get_team_num(); // assume up to 6 teams
       OUT[tm] = (long long) (Rd1 + Rd2);
     }
-  }, VERIFY(0, 1, OUT[0]+OUT[1]+OUT[2]+OUT[3]+OUT[4]+OUT[5],
-            ( (2*N) << 16 ) ));
+  }, {VERIFY(0, 1, OUT[0]+OUT[1]+OUT[2]+OUT[3]+OUT[4]+OUT[5],
+            ( (2*N) << 16 ) ); any_fail += fail; });
 
   //
   // Test: reduction on target parallel.
@@ -502,7 +503,7 @@ int main(void) {
       {
         REDUCTION_FINAL();
       },
-      VERIFY(0, 6, OUT[i], (trial+1) * EXPECTED[i]));
+      {VERIFY(0, 6, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail; });
   }
   DUMP_SUCCESS(gpu_threads-max_threads);
 
@@ -519,7 +520,7 @@ int main(void) {
       {
         REDUCTION_FINAL();
       },
-      VERIFY(0, 6, OUT[i], (trial+1) * EXPECTED[i]));
+      {VERIFY(0, 6, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail; });
   }
   DUMP_SUCCESS(gpu_threads-max_threads);
 
@@ -565,7 +566,7 @@ int main(void) {
           }
         }
       }
-    }, VERIFY(0, 1, OUT[0] + num_tests[0], 0+(trial+1)*2156) );
+    }, {VERIFY(0, 1, OUT[0] + num_tests[0], 0+(trial+1)*2156); any_fail += fail; } );
   }
 
   //
@@ -608,7 +609,7 @@ int main(void) {
           }
         }
       }
-    }, VERIFY(0, 1, OUT[0] + num_tests[0], 0+(trial+1)*2156) );
+    }, {VERIFY(0, 1, OUT[0] + num_tests[0], 0+(trial+1)*2156); any_fail += fail; } );
   }
 
   double double_lb = -DBL_MAX; //-2^1023
@@ -625,7 +626,7 @@ int main(void) {
       for (int i=0; i<1024; i++) {
         foo[0]*=0.5;
       }
-    }, VERIFY_E(0, 1, foo[0], -1.0, 0.0000001f));
+    }, {VERIFY_E(0, 1, foo[0], -1.0, 0.0000001f); any_fail += fail; });
   }
   DUMP_SUCCESS(gpu_threads-max_threads);
 
@@ -639,7 +640,7 @@ int main(void) {
       for (int i=0; i<1024; i++) {
         foo[0]*=0.5;
       }
-    }, VERIFY_E(0, 1, foo[0], 1.0, 0.0000001f));
+    }, {VERIFY_E(0, 1, foo[0], 1.0, 0.0000001f); any_fail += fail; });
   }
   DUMP_SUCCESS(gpu_threads-max_threads);
 
@@ -657,7 +658,7 @@ int main(void) {
       for (int i=0; i<128; i++) {
         bar[0]*=0.5;
       }
-    }, VERIFY_E(0, 1, bar[0], -1.0f, 0.0000001f));
+    }, {VERIFY_E(0, 1, bar[0], -1.0f, 0.0000001f); any_fail += fail; });
   }
   DUMP_SUCCESS(gpu_threads-max_threads);
 
@@ -671,10 +672,10 @@ int main(void) {
       for (int i=0; i<128; i++) {
         bar[0]*=0.5;
       }
-    }, VERIFY_E(0, 1, bar[0], 1.0f, 0.0000001f));
+    }, {VERIFY_E(0, 1, bar[0], 1.0f, 0.0000001f); any_fail += fail; });
   }
   DUMP_SUCCESS(gpu_threads-max_threads);
 
-  return 0;
+  return any_fail > 0;
 }
 

--- a/t-target-api/test.c
+++ b/t-target-api/test.c
@@ -12,6 +12,7 @@
 #define INIT() INIT_LOOP(N, {A[i] = 0; C[i] = 1; D[i] = i; E[i] = -i;})
 
 int main(void){
+  int any_fail = 0;
   #if CHECK
     check_offloading();
   #endif
@@ -71,7 +72,7 @@ int main(void){
   double *dpD = (double *) device_D - 300;
   printf("omp_target_alloc %s\n", device_A && device_C && device_D ?
       "succeeded" : "failed");
-
+  if (!(device_A && device_C && device_D)) any_fail += 1;
   omp_target_memcpy(dpC, pC, N*sizeof(double), 200*sizeof(double),
       20*sizeof(double), default_device_omp_target_call, omp_get_initial_device());
   omp_target_memcpy(dpD, pD, N*sizeof(double), 300*sizeof(double),
@@ -89,6 +90,7 @@ int main(void){
 
   int fail = 0;
   VERIFY(0, N, A[i], (double)(i+2));
+  any_fail += fail;
   if (fail) {
     printf ("Test omp_target_memcpy: Failed\n");
   } else {
@@ -109,6 +111,7 @@ int main(void){
     int rc = omp_target_associate_ptr(C, dpC, N*sizeof(double),
         200*sizeof(double), default_device_omp_target_call);
     printf("omp_target_associate_ptr C %s\n", !rc ? "succeeded" : "failed");
+    if (rc) any_fail += 1;
   }
   if (offloading_disabled()) {
     // If offloading is disabled just recreate the messages so that this can
@@ -120,6 +123,7 @@ int main(void){
     int rc = omp_target_associate_ptr(D, dpD, N*sizeof(double),
         300*sizeof(double), default_device_omp_target_call);
     printf("omp_target_associate_ptr D %s\n", !rc ? "succeeded" : "failed");
+    if (rc) any_fail += 1;
   }
   #pragma omp target data map(from: C, D) device(default_device)
   {
@@ -150,6 +154,7 @@ int main(void){
     printf("C is present, disassociating it...\n");
     int rc = omp_target_disassociate_ptr(C, default_device_omp_target_call);
     printf("omp_target_disassociate_ptr C %s\n", !rc ? "succeeded" : "failed");
+    if (rc) any_fail += 1;
   }
   if (offloading_disabled()) {
     printf("D is present, disassociating it...\n");
@@ -158,10 +163,12 @@ int main(void){
     printf("D is present, disassociating it...\n");
     int rc = omp_target_disassociate_ptr(D, default_device_omp_target_call);
     printf("omp_target_disassociate_ptr D %s\n", !rc ? "succeeded" : "failed");
+    if (rc) any_fail += 1;
   }
 
   fail = 0;
   VERIFY(0, N, A[i], (double)(i+2));
+  any_fail += fail;
   if (fail) {
     printf ("Test omp_target_associate_ptr: Failed\n");
   } else {
@@ -172,5 +179,5 @@ int main(void){
   omp_target_free(device_C, default_device_omp_target_call);
   omp_target_free(device_D, default_device_omp_target_call);
 
-  return 0;
+  return any_fail > 0;
 }

--- a/t-target-nowait-dep-implicit/test.cpp
+++ b/t-target-nowait-dep-implicit/test.cpp
@@ -48,5 +48,5 @@ int main() {
   if (err) printf("Errors!\n");
   else printf("Success!\n");
 
-  return 0;
+  return err;
 }

--- a/t-tdpf-nested-parallel/test.c
+++ b/t-tdpf-nested-parallel/test.c
@@ -19,6 +19,7 @@ double S[M];
 double p[2];
 
 int main(void) {
+  int any_fail = 0;
   check_offloading();
 
   INIT();
@@ -56,7 +57,7 @@ int main(void) {
     }
     S[idx] += tmp;
   },
-  VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))))
+  {VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))); any_fail += fail; })
 
   #undef NESTED_PARALLEL_FOR_CLAUSES
   #define NESTED_PARALLEL_FOR_CLAUSES proc_bind(close)
@@ -77,7 +78,7 @@ int main(void) {
     }
     S[idx] += tmp;
   },
-  VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))))
+  {VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))); any_fail += fail; })
 
   #undef NESTED_PARALLEL_FOR_CLAUSES
   #define NESTED_PARALLEL_FOR_CLAUSES proc_bind(spread)
@@ -98,7 +99,7 @@ int main(void) {
     }
     S[idx] += tmp;
   },
-  VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))))
+  {VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))); any_fail += fail; })
 
   //
   // Test: private, shared clauses on omp teams distribute parallel for with nested parallel.
@@ -127,7 +128,7 @@ int main(void) {
     }
     S[idx] += tmp;
   },
-  VERIFY(0, tms*th, S[i], (double) 6 + SUMS * (N/2*(N+1))))
+  {VERIFY(0, tms*th, S[i], (double) 6 + SUMS * (N/2*(N+1))); any_fail += fail; })
 
   //
   // Test: firstprivate clause on omp teams distribute parallel for with nested parallel.
@@ -158,7 +159,7 @@ int main(void) {
     }
     S[idx] += tmp;
   },
-  VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))))
+  {VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))); any_fail += fail; })
 
   //
   // Test: lastprivate clause on omp teams distribute parallel for with nested parallel.
@@ -200,7 +201,7 @@ int main(void) {
     }
     S[idx] += tmp;
   }
-  }, VERIFY(0, tms*th, S[i], (double) 2 * (N + (N/2*(N+1))) ));
+  }, {VERIFY(0, tms*th, S[i], (double) 2 * (N + (N/2*(N+1))) ); any_fail += fail; });
 
   //
   // Test: private clause on omp teams distribute parallel for with nested parallel.
@@ -230,7 +231,7 @@ int main(void) {
     }
     S[idx] += tmp;
   },
-  VERIFY(0, tms*th, S[i], (double) 6 + SUMS * (N/2*(N+1))))
+  {VERIFY(0, tms*th, S[i], (double) 6 + SUMS * (N/2*(N+1))); any_fail += fail; })
 
   //
   // Test: firstprivate clause on omp teams distribute parallel for with nested parallel.
@@ -262,7 +263,7 @@ int main(void) {
     }
     S[idx] += tmp;
   },
-  VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))))
+  {VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))); any_fail += fail; })
 
   //
   // Test: collapse clause on omp teams distribute parallel for with nested parallel.
@@ -290,7 +291,7 @@ int main(void) {
     }
     S[idx] += tmp;
   },
-  VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))))
+  {VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))); any_fail += fail; })
 
   //
   // Test: ordered clause on omp teams distribute parallel for with nested parallel.
@@ -308,7 +309,7 @@ int main(void) {
   ,
   {
   },
-  VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))))
+  {VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))); any_fail += fail; })
 
   //
   // Test: Ensure coalesced scheduling on GPU.
@@ -339,10 +340,10 @@ int main(void) {
         }
         S[idx] = tmp;
       }
-    }, VERIFY(0, tms*th, S[i], (double) 3 * (32*32 + 64*32) ));
+    }, {VERIFY(0, tms*th, S[i], (double) 3 * (32*32 + 64*32) ); any_fail += fail; });
   } else {
     DUMP_SUCCESS(1);
   }
 
-  return 0;
+  return any_fail > 0;
 }

--- a/t-tp-nested-parallel/test.c
+++ b/t-tp-nested-parallel/test.c
@@ -19,6 +19,7 @@ double S[M];
 double p[2];
 
 int main(void) {
+  int any_fail = 0;
   check_offloading();
 
   INIT();
@@ -55,7 +56,7 @@ int main(void) {
       }
       S[tid] += tmp;
     },
-    VERIFY(0, t, S[i], (double) SUMS * (N/2*(N+1))))
+    {VERIFY(0, t, S[i], (double) SUMS * (N/2*(N+1))); any_fail += fail; })
   }
 
   #undef NESTED_PARALLEL_FOR_CLAUSES
@@ -81,7 +82,7 @@ int main(void) {
       }
       S[tid] += tmp;
     },
-    VERIFY(0, t, S[i], (double) SUMS * (N/2*(N+1))))
+    {VERIFY(0, t, S[i], (double) SUMS * (N/2*(N+1))); any_fail += fail; })
   }
   
   #undef NESTED_PARALLEL_FOR_CLAUSES
@@ -107,7 +108,7 @@ int main(void) {
       }
       S[tid] += tmp;
     },
-    VERIFY(0, t, S[i], (double) SUMS * (N/2*(N+1))))
+    {VERIFY(0, t, S[i], (double) SUMS * (N/2*(N+1))); any_fail += fail; })
   }
 
   //
@@ -141,7 +142,7 @@ int main(void) {
       }
       S[tid] += tmp;
     },
-    VERIFY(0, t, S[i], (double) 6 + SUMS * (N/2*(N+1))))
+    {VERIFY(0, t, S[i], (double) 6 + SUMS * (N/2*(N+1))); any_fail += fail; })
   }
 
   //
@@ -177,7 +178,7 @@ int main(void) {
       }
       S[tid] += tmp;
     },
-    VERIFY(0, t, S[i], (double) SUMS * (N/2*(N+1))))
+    {VERIFY(0, t, S[i], (double) SUMS * (N/2*(N+1))); any_fail += fail; })
   }
 
   //
@@ -221,7 +222,7 @@ int main(void) {
         tmp += A[tid][i] + B[tid][i];
       }
       S[tid] += tmp;
-    }, VERIFY(0, t, S[i], (double) 2 * (N + (N/2*(N+1))) ));
+    }, {VERIFY(0, t, S[i], (double) 2 * (N + (N/2*(N+1))) ); any_fail += fail; });
   }
 
   //
@@ -256,7 +257,7 @@ int main(void) {
       }
       S[tid] += tmp;
     },
-    VERIFY(0, t, S[i], (double) 6 + SUMS * (N/2*(N+1))))
+    {VERIFY(0, t, S[i], (double) 6 + SUMS * (N/2*(N+1))); any_fail += fail; })
   }
 
   //
@@ -293,7 +294,7 @@ int main(void) {
       }
       S[tid] += tmp;
     },
-    VERIFY(0, t, S[i], (double) SUMS * (N/2*(N+1))))
+    {VERIFY(0, t, S[i], (double) SUMS * (N/2*(N+1))); any_fail += fail; })
   }
 
   //
@@ -326,7 +327,7 @@ int main(void) {
       }
       S[tid] += tmp;
     },
-    VERIFY(0, t, S[i], (double) SUMS * (N/2*(N+1))))
+    {VERIFY(0, t, S[i], (double) SUMS * (N/2*(N+1))); any_fail += fail; })
   }
 
   //
@@ -348,7 +349,7 @@ int main(void) {
     ,
     {
     },
-    VERIFY(0, t, S[i], (double) SUMS * (N/2*(N+1))))
+    {VERIFY(0, t, S[i], (double) SUMS * (N/2*(N+1))); any_fail += fail; })
   }
 
   //
@@ -378,10 +379,10 @@ int main(void) {
         tmp += A[tid][i];
       }
       S[tid] = tmp;
-    }, VERIFY(0, 32, S[i], (double) 3 * 95 * 48 ));
+    }, {VERIFY(0, 32, S[i], (double) 3 * 95 * 48 ); any_fail += fail; });
   } else {
     DUMP_SUCCESS(1);
   }
   //DUMP_SUCCESS(1);
-  return 0;
+  return any_fail > 0;
 }

--- a/t-unified-defaultmap/test.cpp
+++ b/t-unified-defaultmap/test.cpp
@@ -4,19 +4,22 @@
 #pragma omp requires unified_shared_memory
 
 #define V(x,y) \
-  if ((x) != (y))\
+  if ((x) != (y)) {\
     printf("Error %d != %d\n", (x), (y));\
-  else\
+    fail = 1; \
+  } else\
     printf("Success!\n");
 #define VPTR(x,y) \
-  if ((x) != (y))\
+  if ((x) != (y)) {\
     printf("Error %p != %p\n", (x), (y));\
-  else\
+    fail = 1; \
+  } else\
     printf("Success!\n");
 
 int A;
 
 int main(void) {
+  int fail = 0;
   int Old = 1;
   int New = Old + 1;
   
@@ -46,5 +49,5 @@ int main(void) {
   VPTR(D, NewPtr);
   VPTR(E, NewPtr);
   
-  return 0;
+  return fail;
 }

--- a/t-unified-distribute-simd-dist-clauses/test.c
+++ b/t-unified-distribute-simd-dist-clauses/test.c
@@ -453,6 +453,6 @@ int main(void) {
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
 
-  return 0;
+  return fail;
 }
 

--- a/t-unified-dpfs-dist-clauses/test.c
+++ b/t-unified-dpfs-dist-clauses/test.c
@@ -456,6 +456,6 @@ int main(void) {
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
 
-  return 0;
+  return fail;
 }
 

--- a/t-unified-flush/test.c
+++ b/t-unified-flush/test.c
@@ -19,6 +19,7 @@ int main(void) {
   check_offloading();
 
   double A[N], B[N], C[N], D[N], E[N];
+  int any_fail = 0;
 
   INIT();
 
@@ -59,7 +60,7 @@ int main(void) {
         }
       }
     }
-  }, VERIFY(0, N, A[i], i + 1));
+  }, {VERIFY(0, N, A[i], i + 1); any_fail += fail; });
 
-  return 0;
+  return any_fail > 0;
 }

--- a/t-unified-for/test.c
+++ b/t-unified-for/test.c
@@ -456,9 +456,10 @@ int main(void) {
       printf("Error\n");
     else
       printf("Succeeded\n");
+    any_fail += fail;
   } else {
     DUMP_SUCCESS(1);
   }
 
-  return 0;
+  return any_fail > 0;
 }

--- a/t-unified-reduction/test.c
+++ b/t-unified-reduction/test.c
@@ -285,6 +285,7 @@ INIT1 + INIT2 + \
 }
 
 int main(void) {
+  int any_fail = 0;
   check_offloading();
 
   char Ac[N], Bc[N], Cc[N], Dc[N], Ec[N];
@@ -336,7 +337,7 @@ int main(void) {
         }
       }
       REDUCTION_FINAL();
-    }, VERIFY(0, 6, OUT[i], (trial+1) * EXPECTED[i]));
+    }, {VERIFY(0, 6, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail; });
   }
   DUMP_SUCCESS(gpu_threads-max_threads);
 
@@ -367,7 +368,7 @@ int main(void) {
         }
       }
       REDUCTION_FINAL();
-    }, VERIFY(0, 6, OUT[i], (trial+1) * 2*EXPECTED[i]));
+    }, {VERIFY(0, 6, OUT[i], (trial+1) * 2*EXPECTED[i]); any_fail += fail; });
   }
 
   //
@@ -387,7 +388,7 @@ int main(void) {
     {
       REDUCTION_FINAL();
     },
-    VERIFY(0, 6, OUT[i], (trial+1) * SUMS * EXPECTED[i]))
+    {VERIFY(0, 6, OUT[i], (trial+1) * SUMS * EXPECTED[i]); any_fail += fail; })
   }
   DUMP_SUCCESS(gpu_threads-max_threads);
 
@@ -412,7 +413,7 @@ int main(void) {
         }
         _Pragma("omp barrier");
       },
-      VERIFY(0, 6, OUT[i], (trial+1) * SUMS * EXPECTED[i]))
+      {VERIFY(0, 6, OUT[i], (trial+1) * SUMS * EXPECTED[i]); any_fail += fail; })
     }
   } else {
     //
@@ -442,7 +443,7 @@ int main(void) {
       R1 += All[1000] + (Bll[1000] + Cll[1000]);
     }
     OUT[0] = R1;
-  }, VERIFY(0, 1, OUT[0], (5ll << 32)));
+  }, {VERIFY(0, 1, OUT[0], (5ll << 32)); any_fail += fail; });
 
   //
   // Test: reduction on parallel sections.
@@ -463,7 +464,7 @@ int main(void) {
       R1 += All[1000] + (Bll[1000] + Cll[1000]);
     }
     OUT[0] = R1;
-  }, VERIFY(0, 1, OUT[0], (5ll << 32)));
+  }, {VERIFY(0, 1, OUT[0], (5ll << 32)); any_fail += fail; });
 
   //
   // Test: reduction on distribute parallel for.
@@ -481,8 +482,8 @@ int main(void) {
       unsigned tm = omp_get_team_num(); // assume 6 teams
       OUT[tm] = (long long) (Rd1 + Rd2);
     }
-  }, VERIFY(0, 1, OUT[0]+OUT[1]+OUT[2]+OUT[3]+OUT[4]+OUT[5],
-            ( (2*N) << 16 ) ));
+  }, {VERIFY(0, 1, OUT[0]+OUT[1]+OUT[2]+OUT[3]+OUT[4]+OUT[5],
+            ( (2*N) << 16 ) ); any_fail += fail; });
 
   //
   // Test: reduction on target parallel.
@@ -503,7 +504,7 @@ int main(void) {
       {
         REDUCTION_FINAL();
       },
-      VERIFY(0, 6, OUT[i], (trial+1) * EXPECTED[i]));
+      {VERIFY(0, 6, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail; });
   }
   DUMP_SUCCESS(gpu_threads-max_threads);
 
@@ -520,7 +521,7 @@ int main(void) {
       {
         REDUCTION_FINAL();
       },
-      VERIFY(0, 6, OUT[i], (trial+1) * EXPECTED[i]));
+      {VERIFY(0, 6, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail; });
   }
   DUMP_SUCCESS(gpu_threads-max_threads);
 
@@ -566,7 +567,7 @@ int main(void) {
           }
         }
       }
-    }, VERIFY(0, 1, OUT[0] + num_tests[0], 0+(trial+1)*2156) );
+    }, {VERIFY(0, 1, OUT[0] + num_tests[0], 0+(trial+1)*2156); any_fail += fail; } );
   }
 
   //
@@ -609,7 +610,7 @@ int main(void) {
           }
         }
       }
-    }, VERIFY(0, 1, OUT[0] + num_tests[0], 0+(trial+1)*2156) );
+    }, {VERIFY(0, 1, OUT[0] + num_tests[0], 0+(trial+1)*2156); any_fail += fail; } );
   }
 
   double double_lb = -DBL_MAX; //-2^1023
@@ -626,7 +627,7 @@ int main(void) {
       for (int i=0; i<1024; i++) {
         foo[0]*=0.5;
       }
-    }, VERIFY_E(0, 1, foo[0], -1.0, 0.0000001f));
+    }, {VERIFY_E(0, 1, foo[0], -1.0, 0.0000001f); any_fail += fail; });
   }
   DUMP_SUCCESS(gpu_threads-max_threads);
 
@@ -640,7 +641,7 @@ int main(void) {
       for (int i=0; i<1024; i++) {
         foo[0]*=0.5;
       }
-    }, VERIFY_E(0, 1, foo[0], 1.0, 0.0000001f));
+    }, {VERIFY_E(0, 1, foo[0], 1.0, 0.0000001f); any_fail += fail; });
   }
   DUMP_SUCCESS(gpu_threads-max_threads);
 
@@ -658,7 +659,7 @@ int main(void) {
       for (int i=0; i<128; i++) {
         bar[0]*=0.5;
       }
-    }, VERIFY_E(0, 1, bar[0], -1.0f, 0.0000001f));
+    }, {VERIFY_E(0, 1, bar[0], -1.0f, 0.0000001f); any_fail += fail; });
   }
   DUMP_SUCCESS(gpu_threads-max_threads);
 
@@ -672,10 +673,10 @@ int main(void) {
       for (int i=0; i<128; i++) {
         bar[0]*=0.5;
       }
-    }, VERIFY_E(0, 1, bar[0], 1.0f, 0.0000001f));
+    }, {VERIFY_E(0, 1, bar[0], 1.0f, 0.0000001f); any_fail += fail; });
   }
   DUMP_SUCCESS(gpu_threads-max_threads);
 
-  return 0;
+  return any_fail > 0;
 }
 

--- a/t-unified-target-api/test.c
+++ b/t-unified-target-api/test.c
@@ -14,6 +14,7 @@
 #define INIT() INIT_LOOP(N, {A[i] = 0; C[i] = 1; D[i] = i; E[i] = -i;})
 
 int main(void){
+  int any_fail = 0;
   #if CHECK
     check_offloading();
   #endif
@@ -73,6 +74,7 @@ int main(void){
   double *dpD = (double *) device_D - 300;
   printf("omp_target_alloc %s\n", device_A && device_C && device_D ?
       "succeeded" : "failed");
+  if (!(device_A && device_C && device_D)) any_fail += 1;
   omp_target_memcpy(dpC, pC, N*sizeof(double), 200*sizeof(double),
       20*sizeof(double), default_device_omp_target_call, omp_get_initial_device());
   omp_target_memcpy(dpD, pD, N*sizeof(double), 300*sizeof(double),
@@ -91,6 +93,7 @@ int main(void){
 
   int fail = 0;
   VERIFY(0, N, A[i], (double)(i+2));
+  any_fail += fail;
   if (fail) {
     printf ("Test omp_target_memcpy: Failed\n");
   } else {
@@ -111,6 +114,7 @@ int main(void){
     int rc = omp_target_associate_ptr(C, dpC, N*sizeof(double),
         200*sizeof(double), default_device_omp_target_call);
     printf("omp_target_associate_ptr C %s\n", !rc ? "succeeded" : "failed");
+    if (rc) any_fail += 1;
   }
   if (offloading_disabled()) {
     // If offloading is disabled just recreate the messages so that this can
@@ -122,6 +126,7 @@ int main(void){
     int rc = omp_target_associate_ptr(D, dpD, N*sizeof(double),
         300*sizeof(double), default_device_omp_target_call);
     printf("omp_target_associate_ptr D %s\n", !rc ? "succeeded" : "failed");
+    if (rc) any_fail += 1;
   }
   #pragma omp target data map(from: C, D) device(default_device)
   {
@@ -152,6 +157,7 @@ int main(void){
     printf("C is present, disassociating it...\n");
     int rc = omp_target_disassociate_ptr(C, default_device_omp_target_call);
     printf("omp_target_disassociate_ptr C %s\n", !rc ? "succeeded" : "failed");
+    if (rc) any_fail += 1;
   }
   if (offloading_disabled()) {
     printf("D is present, disassociating it...\n");
@@ -160,10 +166,12 @@ int main(void){
     printf("D is present, disassociating it...\n");
     int rc = omp_target_disassociate_ptr(D, default_device_omp_target_call);
     printf("omp_target_disassociate_ptr D %s\n", !rc ? "succeeded" : "failed");
+    if (rc) any_fail += 1;
   }
 
   fail = 0;
   VERIFY(0, N, A[i], (double)(i+2));
+  any_fail += fail;
   if (fail) {
     printf ("Test omp_target_associate_ptr: Failed\n");
   } else {
@@ -174,5 +182,5 @@ int main(void){
   omp_target_free(device_C, default_device_omp_target_call);
   omp_target_free(device_D, default_device_omp_target_call);
 
-  return 0;
+  return any_fail > 0;
 }

--- a/t-unified-target-nowait-dep-implicit/test.cpp
+++ b/t-unified-target-nowait-dep-implicit/test.cpp
@@ -50,5 +50,5 @@ int main() {
   if (err) printf("Errors!\n");
   else printf("Success!\n");
 
-  return 0;
+  return err;
 }

--- a/t-unified-tp-nested-parallel/test.c
+++ b/t-unified-tp-nested-parallel/test.c
@@ -21,6 +21,7 @@ double S[M];
 double p[2];
 
 int main(void) {
+  int any_fail = 0;
   check_offloading();
 
   INIT();
@@ -57,7 +58,7 @@ int main(void) {
       }
       S[tid] += tmp;
     },
-    VERIFY(0, t, S[i], (double) SUMS * (N/2*(N+1))))
+    {VERIFY(0, t, S[i], (double) SUMS * (N/2*(N+1))); any_fail += fail; })
   }
 
   #undef NESTED_PARALLEL_FOR_CLAUSES
@@ -83,7 +84,7 @@ int main(void) {
       }
       S[tid] += tmp;
     },
-    VERIFY(0, t, S[i], (double) SUMS * (N/2*(N+1))))
+    {VERIFY(0, t, S[i], (double) SUMS * (N/2*(N+1))); any_fail += fail; })
   }
   
   #undef NESTED_PARALLEL_FOR_CLAUSES
@@ -109,7 +110,7 @@ int main(void) {
       }
       S[tid] += tmp;
     },
-    VERIFY(0, t, S[i], (double) SUMS * (N/2*(N+1))))
+    {VERIFY(0, t, S[i], (double) SUMS * (N/2*(N+1))); any_fail += fail; })
   }
 
   //
@@ -143,7 +144,7 @@ int main(void) {
       }
       S[tid] += tmp;
     },
-    VERIFY(0, t, S[i], (double) 6 + SUMS * (N/2*(N+1))))
+    {VERIFY(0, t, S[i], (double) 6 + SUMS * (N/2*(N+1))); any_fail += fail; })
   }
 
   //
@@ -179,7 +180,7 @@ int main(void) {
       }
       S[tid] += tmp;
     },
-    VERIFY(0, t, S[i], (double) SUMS * (N/2*(N+1))))
+    {VERIFY(0, t, S[i], (double) SUMS * (N/2*(N+1))); any_fail += fail; })
   }
 
   //
@@ -223,7 +224,7 @@ int main(void) {
         tmp += A[tid][i] + B[tid][i];
       }
       S[tid] += tmp;
-    }, VERIFY(0, t, S[i], (double) 2 * (N + (N/2*(N+1))) ));
+    }, {VERIFY(0, t, S[i], (double) 2 * (N + (N/2*(N+1))) ); any_fail += fail; });
   }
 
   //
@@ -258,7 +259,7 @@ int main(void) {
       }
       S[tid] += tmp;
     },
-    VERIFY(0, t, S[i], (double) 6 + SUMS * (N/2*(N+1))))
+    {VERIFY(0, t, S[i], (double) 6 + SUMS * (N/2*(N+1))); any_fail += fail; })
   }
 
   //
@@ -295,7 +296,7 @@ int main(void) {
       }
       S[tid] += tmp;
     },
-    VERIFY(0, t, S[i], (double) SUMS * (N/2*(N+1))))
+    {VERIFY(0, t, S[i], (double) SUMS * (N/2*(N+1))); any_fail += fail; })
   }
 
   //
@@ -328,7 +329,7 @@ int main(void) {
       }
       S[tid] += tmp;
     },
-    VERIFY(0, t, S[i], (double) SUMS * (N/2*(N+1))))
+    {VERIFY(0, t, S[i], (double) SUMS * (N/2*(N+1))); any_fail += fail; })
   }
 
   //
@@ -350,7 +351,7 @@ int main(void) {
     ,
     {
     },
-    VERIFY(0, t, S[i], (double) SUMS * (N/2*(N+1))))
+    {VERIFY(0, t, S[i], (double) SUMS * (N/2*(N+1))); any_fail += fail; })
   }
 
   //
@@ -380,10 +381,10 @@ int main(void) {
         tmp += A[tid][i];
       }
       S[tid] = tmp;
-    }, VERIFY(0, 32, S[i], (double) 3 * 95 * 48 ));
+    }, {VERIFY(0, 32, S[i], (double) 3 * 95 * 48 ); any_fail += fail; });
   } else {
     DUMP_SUCCESS(1);
   }
   //DUMP_SUCCESS(1);
-  return 0;
+  return any_fail > 0;
 }


### PR DESCRIPTION
Replace more 'return 0' by fail-status dependent exit statuses. Additionally, add some fails that were missed during previous conversions.

@doru1004 – please have a look. Thanks!