### PR TITLE
Fix all? remaining exit-status code handling

### DIFF
--- a/t-concurrent-target/test.c
+++ b/t-concurrent-target/test.c
@@ -25,6 +25,7 @@ int main(void){
 #endif
 
   int fail;
+  int any_fail = 0;
   double A[N], B[N], C[N], D[N], E[N];
   double *pA, *pB, *pC, *pD, *pE;
   int t;
@@ -56,6 +57,7 @@ int main(void){
   } else {
     printf ("Test PAR_A: Succeeded\n");
   }
+  any_fail += fail;
 #endif
 
 #if PAR_P
@@ -78,6 +80,7 @@ int main(void){
   } else {
     printf ("Test PAR_P: Succeeded\n");
   }
+  any_fail += fail;
 #endif
 
 #if PAR_1_DATA_A
@@ -103,6 +106,7 @@ int main(void){
   } else {
     printf ("Test PAR_1_DATA_A: Succeeded\n");
   }
+  any_fail += fail;
 #endif
 
 
@@ -129,6 +133,7 @@ int main(void){
   } else {
     printf ("Test PAR_T_DATA_A: Succeeded\n");
   }
+  any_fail += fail;
 #endif
 
 #if PAR_TOFROM_A
@@ -151,6 +156,7 @@ int main(void){
   } else {
     printf ("Test PAR_TOFROM_A: Succeeded\n");
   }
+  any_fail += fail;
 #endif
 
 #if PAR_TOALL_FROM_A  
@@ -174,8 +180,8 @@ int main(void){
   } else {
     printf ("Test PAR_TOALL_FROM_A: Succeeded\n");
   }
+  any_fail += fail;
 #endif
 
-
-  return 0;
+  return any_fail > 0;
 }

--- a/t-critical/test.c
+++ b/t-critical/test.c
@@ -12,6 +12,7 @@ const int Y_VAL = 11;
 
 int main()
 {
+  int any_failures = 0;
   check_offloading();
 
   long cpuExec = 0;
@@ -56,6 +57,7 @@ int main()
       printf("failed %d times\n", failures);
     else
       printf("Succeeded\n");
+    any_failures += failures;
 
     /// Test team-level dependencies with increment
 #pragma omp target map(tofrom: x[:nb], y[:nb])
@@ -81,9 +83,9 @@ int main()
       printf("failed %d times\n", failures);
     else
       printf("Succeeded\n");
-    return failures;
+    any_failures += failures;
   } else {// if !cpuExec
     DUMP_SUCCESS(2);
-    return 0;
   }
+  return any_failures > 0;
 }

--- a/t-data-sharing-many-teams/test.cpp
+++ b/t-data-sharing-many-teams/test.cpp
@@ -5,6 +5,8 @@
 #define Arr(x,i,j,k) ((x)[(i)*(I)*(I) + (j)*(I) + (k)])
 #define TEAM_SIZE 8096
 
+static int any_error = 0;
+
 template<const unsigned I, const unsigned P1, const unsigned P2>
 void foo_device_parallel(unsigned ii, unsigned *ReferenceA, unsigned *ReferenceB) {
   printf("Running device version - parallel...\n");
@@ -63,6 +65,7 @@ void foo_device_parallel(unsigned ii, unsigned *ReferenceA, unsigned *ReferenceB
   for(unsigned i = 0; i<I*I*I; ++i) {
     if (A[i] != B[i]) {
       printf("Error (device) A[i] != B[i] at %08x: %08x != %08x\n", i, A[i], B[i]);
+      any_error = 1;
       break;
     }
   }
@@ -71,6 +74,7 @@ void foo_device_parallel(unsigned ii, unsigned *ReferenceA, unsigned *ReferenceB
     for(unsigned i = 0; i<I*I*I; ++i)
       if (A[i] != ReferenceA[i]) {
         printf("Error A[i] != ReferenceA[i] at %08x: %08x != %08x\n", i, A[i], ReferenceA[i]);
+        any_error = 1;
         break;
       }
     
@@ -78,6 +82,7 @@ void foo_device_parallel(unsigned ii, unsigned *ReferenceA, unsigned *ReferenceB
     for(unsigned i = 0; i<I*I*I; ++i)
       if (B[i] != ReferenceB[i]) {
         printf("Error B[i] != ReferenceB[i] at %08x: %08x != %08x\n", i, B[i], ReferenceB[i]);
+        any_error = 1;
         break;
       }
 
@@ -140,6 +145,7 @@ void foo_device_parallel_parallel(unsigned ii, unsigned *ReferenceA, unsigned *R
   for(unsigned i = 0; i<I*I*I; ++i) {
     if (A[i] != B[i]) {
       printf("Error (device) A[i] != B[i] at %08x: %08x != %08x\n", i, A[i], B[i]);
+      any_error = 1;
       break;
     }
   }
@@ -148,6 +154,7 @@ void foo_device_parallel_parallel(unsigned ii, unsigned *ReferenceA, unsigned *R
     for(unsigned i = 0; i<I*I*I; ++i)
       if (A[i] != ReferenceA[i]) {
         printf("Error A[i] != ReferenceA[i] at %08x: %08x != %08x\n", i, A[i], ReferenceA[i]);
+        any_error = 1;
         break;
       }
     
@@ -155,6 +162,7 @@ void foo_device_parallel_parallel(unsigned ii, unsigned *ReferenceA, unsigned *R
     for(unsigned i = 0; i<I*I*I; ++i)
       if (B[i] != ReferenceB[i]) {
         printf("Error B[i] != ReferenceB[i] at %08x: %08x != %08x\n", i, B[i], ReferenceB[i]);
+        any_error = 1;
         break;
       }
 
@@ -217,6 +225,7 @@ void foo_device_simd(unsigned ii, unsigned *ReferenceA, unsigned *ReferenceB) {
   for(unsigned i = 0; i<I*I*I; ++i) {
     if (A[i] != B[i]) {
       printf("Error (device) A[i] != B[i] at %08x: %08x != %08x\n", i, A[i], B[i]);
+      any_error = 1;
       break;
     }
   }
@@ -225,6 +234,7 @@ void foo_device_simd(unsigned ii, unsigned *ReferenceA, unsigned *ReferenceB) {
     for(unsigned i = 0; i<I*I*I; ++i)
       if (A[i] != ReferenceA[i]) {
         printf("Error A[i] != ReferenceA[i] at %08x: %08x != %08x\n", i, A[i], ReferenceA[i]);
+        any_error = 1;
         break;
       }
     
@@ -232,6 +242,7 @@ void foo_device_simd(unsigned ii, unsigned *ReferenceA, unsigned *ReferenceB) {
     for(unsigned i = 0; i<I*I*I; ++i)
       if (B[i] != ReferenceB[i]) {
         printf("Error B[i] != ReferenceB[i] at %08x: %08x != %08x\n", i, B[i], ReferenceB[i]);
+        any_error = 1;
         break;
       }
 
@@ -296,6 +307,7 @@ void foo_device_parallel_simd(unsigned ii, unsigned *ReferenceA, unsigned *Refer
   for(unsigned i = 0; i<I*I*I; ++i) {
     if (A[i] != B[i]) {
       printf("Error (device) A[i] != B[i] at %08x: %08x != %08x\n", i, A[i], B[i]);
+      any_error = 1;
       break;
     }
   }
@@ -304,6 +316,7 @@ void foo_device_parallel_simd(unsigned ii, unsigned *ReferenceA, unsigned *Refer
     for(unsigned i = 0; i<I*I*I; ++i)
       if (A[i] != ReferenceA[i]) {
         printf("Error A[i] != ReferenceA[i] at %08x: %08x != %08x\n", i, A[i], ReferenceA[i]);
+        any_error = 1;
         break;
       }
     
@@ -311,6 +324,7 @@ void foo_device_parallel_simd(unsigned ii, unsigned *ReferenceA, unsigned *Refer
     for(unsigned i = 0; i<I*I*I; ++i)
       if (B[i] != ReferenceB[i]) {
         printf("Error B[i] != ReferenceB[i] at %08x: %08x != %08x\n", i, B[i], ReferenceB[i]);
+        any_error = 1;
         break;
       }
 
@@ -367,6 +381,7 @@ void foo(unsigned ii) {
   for(unsigned i = 0; i<I*I*I; ++i) {
     if (A[i] != B[i]) {
       printf("Error (host) A[i] != B[i] at %08x: %08x != %08x\n", i, A[i], B[i]);
+      any_error = 1;
       break;
     }
   }
@@ -443,6 +458,7 @@ void foo_ptr_device_parallel(unsigned ii, unsigned *ReferenceA, unsigned *Refere
     for(unsigned i = 0; i<I*I*I; ++i)
       if (A[i] != ReferenceA[i]) {
         printf("Error A[i] != ReferenceA[i] at %08x: %08x != %08x\n", i, A[i], ReferenceA[i]);
+        any_error = 1;
         break;
       }
     
@@ -450,6 +466,7 @@ void foo_ptr_device_parallel(unsigned ii, unsigned *ReferenceA, unsigned *Refere
     for(unsigned i = 0; i<I*I*I; ++i)
       if (B[i] != ReferenceB[i]) {
         printf("Error B[i] != ReferenceB[i] at %08x: %08x != %08x\n", i, B[i], ReferenceB[i]);
+        any_error = 1;
         break;
       }
 
@@ -512,6 +529,7 @@ void foo_ptr_device_parallel_parallel(unsigned ii, unsigned *ReferenceA, unsigne
   for(unsigned i = 0; i<I*I*I; ++i) {
     if (A[i] != B[i]) {
       printf("Error (device) A[i] != B[i] at %08x: %08x != %08x\n", i, A[i], B[i]);
+      any_error = 1;
       break;
     }
   }
@@ -520,6 +538,7 @@ void foo_ptr_device_parallel_parallel(unsigned ii, unsigned *ReferenceA, unsigne
     for(unsigned i = 0; i<I*I*I; ++i)
       if (A[i] != ReferenceA[i]) {
         printf("Error A[i] != ReferenceA[i] at %08x: %08x != %08x\n", i, A[i], ReferenceA[i]);
+        any_error = 1;
         break;
       }
     
@@ -527,6 +546,7 @@ void foo_ptr_device_parallel_parallel(unsigned ii, unsigned *ReferenceA, unsigne
     for(unsigned i = 0; i<I*I*I; ++i)
       if (B[i] != ReferenceB[i]) {
         printf("Error B[i] != ReferenceB[i] at %08x: %08x != %08x\n", i, B[i], ReferenceB[i]);
+        any_error = 1;
         break;
       }
 
@@ -589,6 +609,7 @@ void foo_ptr_device_simd(unsigned ii, unsigned *ReferenceA, unsigned *ReferenceB
   for(unsigned i = 0; i<I*I*I; ++i) {
     if (A[i] != B[i]) {
       printf("Error (device) A[i] != B[i] at %08x: %08x != %08x\n", i, A[i], B[i]);
+      any_error = 1;
       break;
     }
   }
@@ -597,6 +618,7 @@ void foo_ptr_device_simd(unsigned ii, unsigned *ReferenceA, unsigned *ReferenceB
     for(unsigned i = 0; i<I*I*I; ++i)
       if (A[i] != ReferenceA[i]) {
         printf("Error A[i] != ReferenceA[i] at %08x: %08x != %08x\n", i, A[i], ReferenceA[i]);
+        any_error = 1;
         break;
       }
     
@@ -604,6 +626,7 @@ void foo_ptr_device_simd(unsigned ii, unsigned *ReferenceA, unsigned *ReferenceB
     for(unsigned i = 0; i<I*I*I; ++i)
       if (B[i] != ReferenceB[i]) {
         printf("Error B[i] != ReferenceB[i] at %08x: %08x != %08x\n", i, B[i], ReferenceB[i]);
+        any_error = 1;
         break;
       }
 
@@ -668,6 +691,7 @@ void foo_ptr_device_parallel_simd(unsigned ii, unsigned *ReferenceA, unsigned *R
   for(unsigned i = 0; i<I*I*I; ++i) {
     if (A[i] != B[i]) {
       printf("Error (device) A[i] != B[i] at %08x: %08x != %08x\n", i, A[i], B[i]);
+      any_error = 1;
       break;
     }
   }
@@ -676,6 +700,7 @@ void foo_ptr_device_parallel_simd(unsigned ii, unsigned *ReferenceA, unsigned *R
     for(unsigned i = 0; i<I*I*I; ++i)
       if (A[i] != ReferenceA[i]) {
         printf("Error A[i] != ReferenceA[i] at %08x: %08x != %08x\n", i, A[i], ReferenceA[i]);
+        any_error = 1;
         break;
       }
     
@@ -683,6 +708,7 @@ void foo_ptr_device_parallel_simd(unsigned ii, unsigned *ReferenceA, unsigned *R
     for(unsigned i = 0; i<I*I*I; ++i)
       if (B[i] != ReferenceB[i]) {
         printf("Error B[i] != ReferenceB[i] at %08x: %08x != %08x\n", i, B[i], ReferenceB[i]);
+        any_error = 1;
         break;
       }
 
@@ -740,6 +766,7 @@ void foo_ptr(unsigned ii) {
   for(unsigned i = 0; i<I*I*I; ++i) {
     if (A[i] != B[i]) {
       printf("Error (host) A[i] != B[i] at %08x: %08x != %08x\n", i, A[i], B[i]);
+      any_error = 1;
       break;
     }
   }
@@ -839,5 +866,5 @@ int main(void) {
   static_data_sharing();
 
   printf("End!\n");
-  return 0;
+  return any_error;
 }

--- a/t-data-sharing/test.cpp
+++ b/t-data-sharing/test.cpp
@@ -4,6 +4,8 @@
 
 #define Arr(x,i,j,k) ((x)[(i)*(I)*(I) + (j)*(I) + (k)])
 
+static int any_error = 0;
+
 template<const unsigned I, const unsigned P1, const unsigned P2>
 void foo_device_parallel(unsigned ii, unsigned *ReferenceA, unsigned *ReferenceB) {
   printf("Running device version - parallel...\n");
@@ -62,6 +64,7 @@ void foo_device_parallel(unsigned ii, unsigned *ReferenceA, unsigned *ReferenceB
   for(unsigned i = 0; i<I*I*I; ++i) {
     if (A[i] != B[i]) {
       printf("Error (device) A[i] != B[i] at %08x: %08x != %08x\n", i, A[i], B[i]);
+      any_error = 1;
       break;
     }
   }
@@ -70,6 +73,7 @@ void foo_device_parallel(unsigned ii, unsigned *ReferenceA, unsigned *ReferenceB
     for(unsigned i = 0; i<I*I*I; ++i)
       if (A[i] != ReferenceA[i]) {
         printf("Error A[i] != ReferenceA[i] at %08x: %08x != %08x\n", i, A[i], ReferenceA[i]);
+        any_error = 1;
         break;
       }
     
@@ -77,6 +81,7 @@ void foo_device_parallel(unsigned ii, unsigned *ReferenceA, unsigned *ReferenceB
     for(unsigned i = 0; i<I*I*I; ++i)
       if (B[i] != ReferenceB[i]) {
         printf("Error B[i] != ReferenceB[i] at %08x: %08x != %08x\n", i, B[i], ReferenceB[i]);
+        any_error = 1;
         break;
       }
 
@@ -139,6 +144,7 @@ void foo_device_parallel_parallel(unsigned ii, unsigned *ReferenceA, unsigned *R
   for(unsigned i = 0; i<I*I*I; ++i) {
     if (A[i] != B[i]) {
       printf("Error (device) A[i] != B[i] at %08x: %08x != %08x\n", i, A[i], B[i]);
+      any_error = 1;
       break;
     }
   }
@@ -147,6 +153,7 @@ void foo_device_parallel_parallel(unsigned ii, unsigned *ReferenceA, unsigned *R
     for(unsigned i = 0; i<I*I*I; ++i)
       if (A[i] != ReferenceA[i]) {
         printf("Error A[i] != ReferenceA[i] at %08x: %08x != %08x\n", i, A[i], ReferenceA[i]);
+        any_error = 1;
         break;
       }
     
@@ -154,6 +161,7 @@ void foo_device_parallel_parallel(unsigned ii, unsigned *ReferenceA, unsigned *R
     for(unsigned i = 0; i<I*I*I; ++i)
       if (B[i] != ReferenceB[i]) {
         printf("Error B[i] != ReferenceB[i] at %08x: %08x != %08x\n", i, B[i], ReferenceB[i]);
+        any_error = 1;
         break;
       }
 
@@ -216,6 +224,7 @@ void foo_device_simd(unsigned ii, unsigned *ReferenceA, unsigned *ReferenceB) {
   for(unsigned i = 0; i<I*I*I; ++i) {
     if (A[i] != B[i]) {
       printf("Error (device) A[i] != B[i] at %08x: %08x != %08x\n", i, A[i], B[i]);
+      any_error = 1;
       break;
     }
   }
@@ -224,6 +233,7 @@ void foo_device_simd(unsigned ii, unsigned *ReferenceA, unsigned *ReferenceB) {
     for(unsigned i = 0; i<I*I*I; ++i)
       if (A[i] != ReferenceA[i]) {
         printf("Error A[i] != ReferenceA[i] at %08x: %08x != %08x\n", i, A[i], ReferenceA[i]);
+        any_error = 1;
         break;
       }
     
@@ -231,6 +241,7 @@ void foo_device_simd(unsigned ii, unsigned *ReferenceA, unsigned *ReferenceB) {
     for(unsigned i = 0; i<I*I*I; ++i)
       if (B[i] != ReferenceB[i]) {
         printf("Error B[i] != ReferenceB[i] at %08x: %08x != %08x\n", i, B[i], ReferenceB[i]);
+        any_error = 1;
         break;
       }
 
@@ -295,6 +306,7 @@ void foo_device_parallel_simd(unsigned ii, unsigned *ReferenceA, unsigned *Refer
   for(unsigned i = 0; i<I*I*I; ++i) {
     if (A[i] != B[i]) {
       printf("Error (device) A[i] != B[i] at %08x: %08x != %08x\n", i, A[i], B[i]);
+      any_error = 1;
       break;
     }
   }
@@ -303,6 +315,7 @@ void foo_device_parallel_simd(unsigned ii, unsigned *ReferenceA, unsigned *Refer
     for(unsigned i = 0; i<I*I*I; ++i)
       if (A[i] != ReferenceA[i]) {
         printf("Error A[i] != ReferenceA[i] at %08x: %08x != %08x\n", i, A[i], ReferenceA[i]);
+        any_error = 1;
         break;
       }
     
@@ -310,6 +323,7 @@ void foo_device_parallel_simd(unsigned ii, unsigned *ReferenceA, unsigned *Refer
     for(unsigned i = 0; i<I*I*I; ++i)
       if (B[i] != ReferenceB[i]) {
         printf("Error B[i] != ReferenceB[i] at %08x: %08x != %08x\n", i, B[i], ReferenceB[i]);
+        any_error = 1;
         break;
       }
 
@@ -366,6 +380,7 @@ void foo(unsigned ii) {
   for(unsigned i = 0; i<I*I*I; ++i) {
     if (A[i] != B[i]) {
       printf("Error (host) A[i] != B[i] at %08x: %08x != %08x\n", i, A[i], B[i]);
+      any_error = 1;
       break;
     }
   }
@@ -434,6 +449,7 @@ void foo_ptr_device_parallel(unsigned ii, unsigned *ReferenceA, unsigned *Refere
   for(unsigned i = 0; i<I*I*I; ++i) {
     if (A[i] != B[i]) {
       printf("Error (device) A[i] != B[i] at %08x: %08x != %08x\n", i, A[i], B[i]);
+      any_error = 1;
       break;
     }
   }
@@ -442,6 +458,7 @@ void foo_ptr_device_parallel(unsigned ii, unsigned *ReferenceA, unsigned *Refere
     for(unsigned i = 0; i<I*I*I; ++i)
       if (A[i] != ReferenceA[i]) {
         printf("Error A[i] != ReferenceA[i] at %08x: %08x != %08x\n", i, A[i], ReferenceA[i]);
+        any_error = 1;
         break;
       }
     
@@ -449,6 +466,7 @@ void foo_ptr_device_parallel(unsigned ii, unsigned *ReferenceA, unsigned *Refere
     for(unsigned i = 0; i<I*I*I; ++i)
       if (B[i] != ReferenceB[i]) {
         printf("Error B[i] != ReferenceB[i] at %08x: %08x != %08x\n", i, B[i], ReferenceB[i]);
+        any_error = 1;
         break;
       }
 
@@ -511,6 +529,7 @@ void foo_ptr_device_parallel_parallel(unsigned ii, unsigned *ReferenceA, unsigne
   for(unsigned i = 0; i<I*I*I; ++i) {
     if (A[i] != B[i]) {
       printf("Error (device) A[i] != B[i] at %08x: %08x != %08x\n", i, A[i], B[i]);
+      any_error = 1;
       break;
     }
   }
@@ -519,6 +538,7 @@ void foo_ptr_device_parallel_parallel(unsigned ii, unsigned *ReferenceA, unsigne
     for(unsigned i = 0; i<I*I*I; ++i)
       if (A[i] != ReferenceA[i]) {
         printf("Error A[i] != ReferenceA[i] at %08x: %08x != %08x\n", i, A[i], ReferenceA[i]);
+        any_error = 1;
         break;
       }
     
@@ -526,6 +546,7 @@ void foo_ptr_device_parallel_parallel(unsigned ii, unsigned *ReferenceA, unsigne
     for(unsigned i = 0; i<I*I*I; ++i)
       if (B[i] != ReferenceB[i]) {
         printf("Error B[i] != ReferenceB[i] at %08x: %08x != %08x\n", i, B[i], ReferenceB[i]);
+        any_error = 1;
         break;
       }
 
@@ -588,6 +609,7 @@ void foo_ptr_device_simd(unsigned ii, unsigned *ReferenceA, unsigned *ReferenceB
   for(unsigned i = 0; i<I*I*I; ++i) {
     if (A[i] != B[i]) {
       printf("Error (device) A[i] != B[i] at %08x: %08x != %08x\n", i, A[i], B[i]);
+      any_error = 1;
       break;
     }
   }
@@ -596,6 +618,7 @@ void foo_ptr_device_simd(unsigned ii, unsigned *ReferenceA, unsigned *ReferenceB
     for(unsigned i = 0; i<I*I*I; ++i)
       if (A[i] != ReferenceA[i]) {
         printf("Error A[i] != ReferenceA[i] at %08x: %08x != %08x\n", i, A[i], ReferenceA[i]);
+        any_error = 1;
         break;
       }
     
@@ -603,6 +626,7 @@ void foo_ptr_device_simd(unsigned ii, unsigned *ReferenceA, unsigned *ReferenceB
     for(unsigned i = 0; i<I*I*I; ++i)
       if (B[i] != ReferenceB[i]) {
         printf("Error B[i] != ReferenceB[i] at %08x: %08x != %08x\n", i, B[i], ReferenceB[i]);
+        any_error = 1;
         break;
       }
 
@@ -667,6 +691,7 @@ void foo_ptr_device_parallel_simd(unsigned ii, unsigned *ReferenceA, unsigned *R
   for(unsigned i = 0; i<I*I*I; ++i) {
     if (A[i] != B[i]) {
       printf("Error (device) A[i] != B[i] at %08x: %08x != %08x\n", i, A[i], B[i]);
+      any_error = 1;
       break;
     }
   }
@@ -675,6 +700,7 @@ void foo_ptr_device_parallel_simd(unsigned ii, unsigned *ReferenceA, unsigned *R
     for(unsigned i = 0; i<I*I*I; ++i)
       if (A[i] != ReferenceA[i]) {
         printf("Error A[i] != ReferenceA[i] at %08x: %08x != %08x\n", i, A[i], ReferenceA[i]);
+        any_error = 1;
         break;
       }
     
@@ -682,6 +708,7 @@ void foo_ptr_device_parallel_simd(unsigned ii, unsigned *ReferenceA, unsigned *R
     for(unsigned i = 0; i<I*I*I; ++i)
       if (B[i] != ReferenceB[i]) {
         printf("Error B[i] != ReferenceB[i] at %08x: %08x != %08x\n", i, B[i], ReferenceB[i]);
+        any_error = 1;
         break;
       }
 
@@ -739,6 +766,7 @@ void foo_ptr(unsigned ii) {
   for(unsigned i = 0; i<I*I*I; ++i) {
     if (A[i] != B[i]) {
       printf("Error (host) A[i] != B[i] at %08x: %08x != %08x\n", i, A[i], B[i]);
+      any_error = 1;
       break;
     }
   }
@@ -838,5 +866,5 @@ int main(void) {
   static_data_sharing();
 
   printf("End!\n");
-  return 0;
+  return any_error;
 }

--- a/t-declare-simd/test.c
+++ b/t-declare-simd/test.c
@@ -45,6 +45,7 @@ int foo_notinbranch(int *b, int c) {
 
 int main()
 {
+  int any_fail = 0;
   check_offloading();
 
   int a[N], aa[N], b[N];
@@ -82,6 +83,7 @@ int main()
     printf("failed\n");
   else
     printf("success\n");
+  any_fail += fail;
 
   /// Test: simdlen
   fail = 0;
@@ -116,6 +118,7 @@ int main()
     printf("failed\n");
   else
     printf("success\n");
+  any_fail += fail;
 
   /// Test: linear
   fail = 0;
@@ -153,6 +156,7 @@ int main()
     printf("failed\n");
   else
     printf("success\n");
+  any_fail += fail;
 
   /// Test: aligned
   fail = 0;
@@ -190,6 +194,7 @@ int main()
     printf("failed\n");
   else
     printf("success\n");
+  any_fail += fail;
 
   /// Test: uniform
   fail = 0;
@@ -228,6 +233,7 @@ int main()
     printf("failed\n");
   else
     printf("success\n");
+  any_fail += fail;
 
   /// Test: inbranch
   fail = 0;
@@ -268,6 +274,7 @@ int main()
     printf("failed\n");
   else
     printf("success\n");
+  any_fail += fail;
 
   /// Test: notinbranch
   fail = 0;
@@ -306,6 +313,7 @@ int main()
     printf("failed\n");
   else
     printf("success\n");
+  any_fail += fail;
 
-  return 0;
+  return any_fail > 0;
 }

--- a/t-declare-target/test.cpp
+++ b/t-declare-target/test.cpp
@@ -32,7 +32,7 @@ int t1_G1 = 2;
 
 int t1_G2 = 3;
 
-void t1(int a /* = 1 */) {
+int t1(int a /* = 1 */) {
   int A[1] = {0};
 
   #pragma omp target
@@ -46,6 +46,7 @@ void t1(int a /* = 1 */) {
     printf("Error %d != %d\n",A[0], Expected);
   else
     printf("Success!\n");
+  return A[0] != Expected;
 }
 
 //#######################################
@@ -73,7 +74,7 @@ struct t2_d2 {
 
 #pragma omp end declare target
 
-void t2(int a /* = 1 */) {
+int t2(int a /* = 1 */) {
   t2_d1 A;
   t2_d2<int> B;
   
@@ -93,6 +94,7 @@ void t2(int a /* = 1 */) {
     printf("Error %d != %d\n",A.Val, Expected);
   else
     printf("Success!\n");
+  return A.Val != Expected;
 }
 
 //#######################################
@@ -100,12 +102,12 @@ void t2(int a /* = 1 */) {
 //#######################################
 
 int main(int argc, char *argv[]) {
+  int fail = 0;
   check_offloading();
   
-  t1(argc ? 1 : 5);
-  t2(argc ? 1 : 5);
+  fail += t1(argc ? 1 : 5);
+  fail += t2(argc ? 1 : 5);
   
   printf("Done!\n");
-  return 0;
+  return fail > 0;
 }
-

--- a/t-distribute-simd/test.c
+++ b/t-distribute-simd/test.c
@@ -34,11 +34,11 @@ int main()
       printf("%d: a %d != %d (error %d)\n", i, a[i], aa[i], ++error);
     if (error > 10) {
       printf("abort\n");
-      return 0;
+      return 1;
     }
   }
 
   // report
   printf("done with %d errors\n", error);
-  return error;
+  return error > 0;
 }

--- a/t-distribute/test.c
+++ b/t-distribute/test.c
@@ -14,6 +14,7 @@
 #define ZERO(X) ZERO_ARRAY(N, X)
 
 int main(void) {
+  int any_fail = 0;
   check_offloading();
 
   double A[N], B[N], C[N], D[N], E[N];
@@ -45,6 +46,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: #iterations > #teams
@@ -66,6 +68,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: #iterations < #teams
@@ -87,6 +90,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   // ****************************
   // Series 2: with dist_schedule
@@ -112,6 +116,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: #iterations == #teams, dist_schedule(#iterations)
@@ -133,6 +138,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: #iterations == #teams, dist_schedule(#iterations/10), variable chunk size
@@ -156,6 +162,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: #iterations > #teams, dist_schedule(1)
@@ -177,6 +184,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: #iterations > #teams, dist_schedule(#iterations)
@@ -198,6 +206,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: #iterations > #teams, dist_schedule(#iterations/10), variable chunk size
@@ -221,6 +230,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: #iterations < #teams, dist_schedule(1)
@@ -242,6 +252,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: #iterations < #teams, dist_schedule(#iterations)
@@ -263,6 +274,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: #iterations < #teams, dist_schedule(#iterations)
@@ -286,6 +298,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   // ****************************
   // Series 3: with ds attributes
@@ -321,6 +334,7 @@ int main(void) {
   }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: firstprivate
@@ -363,6 +377,7 @@ int main(void) {
   }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: lastprivate
@@ -382,6 +397,7 @@ int main(void) {
 
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
 
   // ***************************
@@ -418,6 +434,7 @@ int main(void) {
 
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: blocking loop where upper bound is not a multiple of tl*nte
@@ -450,6 +467,7 @@ int main(void) {
 
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   // **************************
   // Series 5: collapse
@@ -485,6 +503,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: 3 loops
@@ -518,7 +537,8 @@ int main(void) {
 	}
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
-  return 0;
+  return any_fail > 0;
 }
 

--- a/t-exceptions/test.cpp
+++ b/t-exceptions/test.cpp
@@ -26,5 +26,5 @@ int main(void) {
   ++A[0];
 
   printf("Got %d, should be 3\n", A[0]);
-  return 0;
+  return 3 != A[0];
 }

--- a/t-large-args/test.c
+++ b/t-large-args/test.c
@@ -25,6 +25,7 @@
 #define SUM400 SUM200 + SUM100(2) + SUM100(3)
 
 int main(void) {
+  int any_fail = 0;
   check_offloading();
 
   double A[N], B[N], C[N], D[N], E[N];
@@ -61,7 +62,7 @@ int main(void) {
    for (int i = 0; i < 1024; i++) {
      A[i] += SUM10(00);
    }
-  }, VERIFY(0, 1024, A[i], 70 ));
+  }, {VERIFY(0, 1024, A[i], 70 ); any_fail += fail;});
 
-  return 0;
+  return any_fail > 0;
 }

--- a/t-master/test.c
+++ b/t-master/test.c
@@ -14,6 +14,7 @@
 #define ZERO(X) ZERO_ARRAY(N, X) 
 
 int main(void) {
+  int any_fail = 0;
   check_offloading();
 
   double A[N], B[N], C[N], D[N], E[N];
@@ -48,8 +49,8 @@ int main(void) {
           B[i] += A[i];
         }
       }
-    }, VERIFY(0, N, B[i], 3*i+2));
+    }, {VERIFY(0, N, B[i], 3*i+2); any_fail += fail;});
   }
 
-  return 0;
+  return any_fail > 0;
 }

--- a/t-multiple-compilation-units/omptests.c
+++ b/t-multiple-compilation-units/omptests.c
@@ -24,7 +24,7 @@ int main()
   }
   
   printf("--> %s <--\n",(res < 90.001 && res > 89.999) ? "success" : "error");
-  return 0;
+  return !(res < 90.001 && res > 89.999);
 }
 
 /// Presumably creates an .omp_offloading.entry

--- a/t-parallel-for-simd/test.c
+++ b/t-parallel-for-simd/test.c
@@ -14,6 +14,7 @@
 #define ZERO(X) ZERO_ARRAY(N, X) 
 
 int main(void) {
+  int any_fail = 0;
   check_offloading();
 
   double A[N], B[N], C[N], D[N], E[N];
@@ -51,7 +52,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))); any_fail += fail;})
   }
   printf("B\n");
   #undef PARALLEL_FOR_CLAUSES
@@ -77,7 +78,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))); any_fail += fail;})
   }
   printf("C\n");
   #undef PARALLEL_FOR_CLAUSES
@@ -103,7 +104,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))); any_fail += fail;})
   }
   printf("D\n");
   #undef PARALLEL_FOR_CLAUSES
@@ -129,7 +130,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))); any_fail += fail;})
   }
 
   //
@@ -163,7 +164,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], 6 + SUMS * (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], 6 + SUMS * (N/2*(N+1))); any_fail += fail;})
   }
 
   //
@@ -199,7 +200,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))); any_fail += fail;})
   }
 
   //
@@ -270,7 +271,7 @@ int main(void) {
         tmp += A[i] + B[i];
       }
       S[0] += tmp;
-    }, VERIFY(0, 1, S[0], 5 * (N + (N/2*(N+1))) ));
+    }, {VERIFY(0, 1, S[0], 5 * (N + (N/2*(N+1)))); any_fail += fail;} );
   }
 
   //
@@ -303,7 +304,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], 6 + SUMS * (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], 6 + SUMS * (N/2*(N+1))); any_fail += fail;})
   }
 
   //
@@ -339,7 +340,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))); any_fail += fail;})
   }
 
   //
@@ -371,7 +372,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))); any_fail += fail;})
   }
 
   //
@@ -403,7 +404,7 @@ int main(void) {
         tmp += A[i];
       }
       S[0] = tmp;
-    }, VERIFY(0, 1, S[0], 3 * (33*33 + 66*33) ));
+    }, {VERIFY(0, 1, S[0], 3 * (33*33 + 66*33) ); any_fail += fail;});
   }
 
   //
@@ -433,7 +434,7 @@ int main(void) {
     for(int i=0; i<N; i++)
       aa[i] += i * SUMS;
   },
-  VERIFY_ARRAY(0, N, aa, a));
+  {VERIFY_ARRAY(0, N, aa, a); any_fail += fail;});
 
   //
   // Test: lastprivate clause on omp parallel for.
@@ -461,7 +462,7 @@ int main(void) {
       aa[i] += i * SUMS;
     aa[0] += SUMS * (N - 1);
   },
-  VERIFY_ARRAY(0, N, aa, a));
+  {VERIFY_ARRAY(0, N, aa, a); any_fail += fail;});
 
   //
   // Test: lastprivate clause on omp parallel for.
@@ -487,7 +488,7 @@ int main(void) {
     for(int i=0; i<N; i++)
       aa[i] += 2 * i * SUMS;
   },
-  VERIFY_ARRAY(0, N, aa, a));
+  {VERIFY_ARRAY(0, N, aa, a); any_fail += fail;});
 
   //
   // Test: lastprivate clause on omp parallel for.
@@ -513,7 +514,7 @@ int main(void) {
     for(int i=0; i<N; i++)
       aa[i] += i * SUMS;
   },
-  VERIFY_ARRAY(0, N, aa, a));
+  {VERIFY_ARRAY(0, N, aa, a); any_fail += fail;});
 
   //
   // Test: safelen clause on omp parallel for.
@@ -540,7 +541,7 @@ int main(void) {
     for(int i=0; i<N; i++)
       aa[i] = i;
   },
-  VERIFY_ARRAY(0, N, aa, a));
+  {VERIFY_ARRAY(0, N, aa, a); any_fail += fail;});
 
-  return 0;
+  return any_fail > 0;
 }

--- a/t-parallel-for/test.c
+++ b/t-parallel-for/test.c
@@ -14,6 +14,7 @@
 #define ZERO(X) ZERO_ARRAY(N, X) 
 
 int main(void) {
+  int any_fail = 0;
   check_offloading();
 
   double A[N], B[N], C[N], D[N], E[N];
@@ -49,7 +50,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))); any_fail += fail;})
   }
   printf("B\n");
   #undef PARALLEL_FOR_CLAUSES
@@ -75,7 +76,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))); any_fail += fail;})
   }
   printf("C\n");
   #undef PARALLEL_FOR_CLAUSES
@@ -101,7 +102,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))); any_fail += fail;})
   }
   printf("D\n");
   #undef PARALLEL_FOR_CLAUSES
@@ -127,7 +128,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))); any_fail += fail;})
   }
 
   //
@@ -161,7 +162,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], 6 + SUMS * (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], 6 + SUMS * (N/2*(N+1))); any_fail += fail;})
   }
 
   //
@@ -197,7 +198,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))); any_fail += fail;})
   }
 
   //
@@ -268,7 +269,7 @@ int main(void) {
         tmp += A[i] + B[i];
       }
       S[0] += tmp;
-    }, VERIFY(0, 1, S[0], 5 * (N + (N/2*(N+1))) ));
+    }, {VERIFY(0, 1, S[0], 5 * (N + (N/2*(N+1))) ); any_fail += fail;});
   }
 
   //
@@ -301,7 +302,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], 6 + SUMS * (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], 6 + SUMS * (N/2*(N+1))); any_fail += fail;})
   }
 
   //
@@ -337,7 +338,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))); any_fail += fail;})
   }
 
   //
@@ -369,7 +370,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))); any_fail += fail;})
   }
 
   //
@@ -391,7 +392,7 @@ int main(void) {
     ,
     {
     },
-    VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))); any_fail += fail;})
   }
 
   //
@@ -423,8 +424,8 @@ int main(void) {
         tmp += A[i];
       }
       S[0] = tmp;
-    }, VERIFY(0, 1, S[0], 3 * (33*33 + 66*33) ));
+    }, {VERIFY(0, 1, S[0], 3 * (33*33 + 66*33) ); any_fail += fail;});
   }
 
-  return 0;
+  return any_fail > 0;
 }

--- a/t-parforsimd/test.c
+++ b/t-parforsimd/test.c
@@ -34,11 +34,11 @@ int main()
       printf("%d: a %d != %d (error %d)\n", i, a[i], aa[i], ++error);
     if (error > 10) {
       printf("abort\n");
-      return 0;
+      return 1;
     }
   }
 
   // report
   printf("done with %d errors\n", error);
-  return error;
+  return error > 0;
 }

--- a/t-reduction-struct/test.cpp
+++ b/t-reduction-struct/test.cpp
@@ -79,6 +79,7 @@ N*5 \
 }
 
 int main(void) {
+  int any_fail = 0;
   check_offloading();
 
   struct DataTy Data;
@@ -109,9 +110,9 @@ int main(void) {
         {
           REDUCTION_FINAL();
         },
-        VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+        {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
     }
   }
 
-  return 0;
+  return any_fail > 0;
 }

--- a/t-reduction-team/test.c
+++ b/t-reduction-team/test.c
@@ -88,6 +88,7 @@ INIT1 + INIT2 + \
 }
 
 int main(void) {
+  int any_fail = 0;
   check_offloading();
 
   double Ad[N], Bd[N], Cd[N], Dd[N], Ed[N];
@@ -136,7 +137,7 @@ int main(void) {
       },
       {
         REDUCTION_FINAL();
-      }, VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+      }, {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
   }
 
   //
@@ -161,7 +162,7 @@ int main(void) {
       },
       {
         REDUCTION_FINAL();
-      }, VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+      }, {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
   }
 
   //
@@ -184,7 +185,7 @@ int main(void) {
       },
       {
         REDUCTION_FINAL();
-      }, VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+      }, {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
   }
 
   //
@@ -208,7 +209,7 @@ int main(void) {
       },
       {
         REDUCTION_FINAL();
-      }, VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+      }, {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
   }
 
   //
@@ -231,7 +232,7 @@ int main(void) {
     },
     {
       REDUCTION_FINAL();
-    }, VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+    }, {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
 
   //
   // Test: reduction on target teams distribute parallel for.
@@ -247,7 +248,7 @@ int main(void) {
         {
           REDUCTION_FINAL();
         },
-        VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+        {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
     }
   }
 
@@ -265,7 +266,7 @@ int main(void) {
         {
           REDUCTION_FINAL();
         },
-        VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+        {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
     }
   }
 
@@ -284,7 +285,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -303,7 +304,7 @@ int main(void) {
         {
           REDUCTION_FINAL();
         },
-        VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+        {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
     }
   }
 
@@ -322,7 +323,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -341,7 +342,7 @@ int main(void) {
         {
           REDUCTION_FINAL();
         },
-        VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+        {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
     }
   }
 
@@ -359,7 +360,7 @@ int main(void) {
         {
           REDUCTION_FINAL();
         },
-        VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+        {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
     }
   }
 
@@ -378,7 +379,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -398,7 +399,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -418,7 +419,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -438,7 +439,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -458,7 +459,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -478,7 +479,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -498,7 +499,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -518,7 +519,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -538,7 +539,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -560,7 +561,7 @@ int main(void) {
         {
           REDUCTION_FINAL();
         },
-        VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+        {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
     }
   }
 
@@ -581,7 +582,7 @@ int main(void) {
         {
           REDUCTION_FINAL();
         },
-        VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+        {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
     }
   }
 
@@ -603,7 +604,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -625,7 +626,7 @@ int main(void) {
         {
           REDUCTION_FINAL();
         },
-        VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+        {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
     }
   }
 
@@ -647,7 +648,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -669,7 +670,7 @@ int main(void) {
         {
           REDUCTION_FINAL();
         },
-        VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+        {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
     }
   }
 
@@ -690,7 +691,7 @@ int main(void) {
         {
           REDUCTION_FINAL();
         },
-        VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+        {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
     }
   }
 
@@ -712,7 +713,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -735,7 +736,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -758,7 +759,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -781,7 +782,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -804,7 +805,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -827,7 +828,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -850,7 +851,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -873,7 +874,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -896,7 +897,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -915,7 +916,7 @@ int main(void) {
         {
           REDUCTION_FINAL();
         },
-        VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+        {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
     }
   }
 
@@ -933,7 +934,7 @@ int main(void) {
         {
           REDUCTION_FINAL();
         },
-        VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+        {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
     }
   }
 
@@ -952,7 +953,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -971,7 +972,7 @@ int main(void) {
         {
           REDUCTION_FINAL();
         },
-        VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+        {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
     }
   }
 
@@ -990,7 +991,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -1009,7 +1010,7 @@ int main(void) {
         {
           REDUCTION_FINAL();
         },
-        VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+        {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
     }
   }
 
@@ -1027,7 +1028,7 @@ int main(void) {
         {
           REDUCTION_FINAL();
         },
-        VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+        {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
     }
   }
 
@@ -1046,7 +1047,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -1066,7 +1067,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -1086,7 +1087,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -1106,7 +1107,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -1126,7 +1127,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -1146,7 +1147,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -1166,7 +1167,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -1186,7 +1187,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -1206,7 +1207,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -1228,7 +1229,7 @@ int main(void) {
         {
           REDUCTION_FINAL();
         },
-        VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+        {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
     }
   }
 
@@ -1249,7 +1250,7 @@ int main(void) {
         {
           REDUCTION_FINAL();
         },
-        VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+        {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
     }
   }
 
@@ -1271,7 +1272,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -1293,7 +1294,7 @@ int main(void) {
         {
           REDUCTION_FINAL();
         },
-        VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+        {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
     }
   }
 
@@ -1315,7 +1316,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -1337,7 +1338,7 @@ int main(void) {
         {
           REDUCTION_FINAL();
         },
-        VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+        {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
     }
   }
 
@@ -1358,7 +1359,7 @@ int main(void) {
         {
           REDUCTION_FINAL();
         },
-        VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+        {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
     }
   }
 
@@ -1380,7 +1381,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -1403,7 +1404,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -1426,7 +1427,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -1449,7 +1450,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -1472,7 +1473,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -1495,7 +1496,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -1518,7 +1519,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -1541,7 +1542,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -1564,10 +1565,10 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
 
-  return 0;
+  return any_fail > 0;
 }

--- a/t-runtime-calls/test.c
+++ b/t-runtime-calls/test.c
@@ -435,8 +435,6 @@ int main(void) {
     }
     }, {VERIFY(0, 1, A[i], omp_is_initial_device() ? A[1] - A[1] : 2.0); any_fail += fail;});
 
-  return 0;
-
 #if 0
   //
   // Test: omp_get_initial_device(). Unspecified behavior when

--- a/t-simd-aligned/test.c
+++ b/t-simd-aligned/test.c
@@ -36,11 +36,11 @@ int main()
       printf("%d: a %d != %d (error %d)\n", i, a[i], aa[i], ++error);
     if (error > 10) {
       printf("abort\n");
-      return 0;
+      return 1;
     }
   }
 
   // report
   printf("done with %d errors\n", error);
-  return error;
+  return error > 0;
 }

--- a/t-simd-collapse/test.c
+++ b/t-simd-collapse/test.c
@@ -35,11 +35,11 @@ int main()
       printf("%d: a %d != %d (error %d)\n", i, a[i], aa[i], ++error);
     if (error > 10) {
       printf("abort\n");
-      return 0;
+      return 1;
     }
   }
 
   // report
   printf("done with %d errors\n", error);
-  return error;
+  return error > 0;
 }

--- a/t-simd-lastprivate/test.c
+++ b/t-simd-lastprivate/test.c
@@ -38,11 +38,11 @@ int main()
       printf("%d: a %d != %d (error %d)\n", i, a[i], aa[i], ++error);
     if (error > 10) {
       printf("abort\n");
-      return 0;
+      return 1;
     }
   }
 
   // report
   printf("done with %d errors\n", error);
-  return error;
+  return error > 0;
 }

--- a/t-simd-linear/test.c
+++ b/t-simd-linear/test.c
@@ -36,11 +36,11 @@ int main()
       printf("%d: a %d != %d (error %d)\n", i, a[i], aa[i], ++error);
     if (error > 10) {
       printf("abort\n");
-      return 0;
+      return 1;
     }
   }
 
   // report
   printf("done with %d errors\n", error);
-  return error;
+  return error > 0;
 }

--- a/t-simd-private/test.c
+++ b/t-simd-private/test.c
@@ -36,11 +36,11 @@ int main()
       printf("%d: a %d != %d (error %d)\n", i, a[i], aa[i], ++error);
     if (error > 10) {
       printf("abort\n");
-      return 0;
+      return 1;
     }
   }
 
   // report
   printf("done with %d errors\n", error);
-  return error;
+  return error > 0;
 }

--- a/t-simd-safelen/test.c
+++ b/t-simd-safelen/test.c
@@ -38,11 +38,11 @@ int main()
       printf("%d: a %d != %d (error %d)\n", i, a[i], aa[i], ++error);
     if (error > 10) {
       printf("abort\n");
-      return 0;
+      return 1;
     }
   }
 
   // report
   printf("done with %d errors\n", error);
-  return error;
+  return error > 0;
 }

--- a/t-simd/test.c
+++ b/t-simd/test.c
@@ -34,11 +34,11 @@ int main()
       printf("%d: a %d != %d (error %d)\n", i, a[i], aa[i], ++error);
     if (error > 10) {
       printf("abort\n");
-      return 0;
+      return 1;
     }
   }
 
   // report
   printf("done with %d errors\n", error);
-  return error;
+  return error > 0;
 }

--- a/t-single/test.c
+++ b/t-single/test.c
@@ -14,6 +14,7 @@
 #define ZERO(X) ZERO_ARRAY(N, X) 
 
 int main(void) {
+  int any_fail = 0;
   check_offloading();
 
   double A[N], B[N], C[N], D[N], E[N];
@@ -47,7 +48,7 @@ int main(void) {
           B[i] += A[i];
         }
       }
-    }, VERIFY(0, N, B[i], 3*i+2));
+    }, {VERIFY(0, N, B[i], 3*i+2); any_fail += fail;});
   }
 
   //
@@ -77,7 +78,7 @@ int main(void) {
           B[i] += A[i];
         }
       }
-    }, VERIFY(0, N, B[i], 2*i+1));
+    }, {VERIFY(0, N, B[i], 2*i+1); any_fail += fail;});
   }
 
   //
@@ -108,7 +109,7 @@ int main(void) {
           B[i] += A[i];
         }
       }
-    }, VERIFY(0, N, B[i], 3*i+3));
+    }, {VERIFY(0, N, B[i], 3*i+3); any_fail += fail;});
   }
 
 #if 0
@@ -140,9 +141,9 @@ int main(void) {
       for (int i = 0; i < N; i++) {
         B[i] += A[i];
       }
-    }, VERIFY(0, N, B[i], 4*i+3));
+    }, {VERIFY(0, N, B[i], 4*i+3); any_fail += fail;});
   }
 #endif
 
-  return 0;
+  return any_fail > 0;
 }

--- a/t-target-basic/test.c
+++ b/t-target-basic/test.c
@@ -10,6 +10,7 @@
 #define INIT() INIT_LOOP(N, {C[i] = 1; D[i] = i; E[i] = -i;})
 
 int main(void){
+  int any_fail = 0;
   check_offloading();
 
   int fail;
@@ -35,6 +36,7 @@ int main(void){
   } else {
     printf ("Test1: Succeeded\n");
   }
+  any_fail += fail;
 #endif
 
   //
@@ -57,6 +59,7 @@ int main(void){
   } else {
     printf ("Test2: Succeeded\n");
   }
+  any_fail += fail;
 
   //
   // Test: Printf on device
@@ -77,5 +80,5 @@ int main(void){
     printf ("Parallel %d:%f\n", TT[1], D[1]);
   }
 
-  return 0;
+  return any_fail > 0;
 }

--- a/t-target-map-ptr/test.cpp
+++ b/t-target-map-ptr/test.cpp
@@ -32,6 +32,7 @@ typedef struct S {
 } S;
 
 int main(void){
+  int any_fail = 0;
   #if CHECK
     check_offloading();
   #endif
@@ -73,6 +74,7 @@ int main(void){
   } else {
     printf ("Test full extent: Succeeded\n");
   }
+  any_fail += fail;
 #endif
 
 #if FULL_ZERO
@@ -99,6 +101,7 @@ int main(void){
   } else {
     printf ("Test full extent with zero length ptrs: Succeeded\n");
   }
+  any_fail += fail;
 #endif
 
   #if FULL_ZERO_NULL
@@ -141,6 +144,7 @@ int main(void){
   } else {
     printf ("Test full extent with zero length ptrs and NULL ptr: Succeeded\n");
   }
+  any_fail += fail;
 #endif
 
 #if FULL_ZERO_IMPLICIT
@@ -166,6 +170,7 @@ int main(void){
   } else {
     printf ("Test full extent with implicit zero length ptrs: Succeeded\n");
   }
+  any_fail += fail;
 #endif
 
 #if FULL_S
@@ -189,6 +194,7 @@ int main(void){
   } else {
     printf ("Test full extent struct: Succeeded\n");
   }
+  any_fail += fail;
 #endif
 
 #if OFFSET
@@ -214,6 +220,7 @@ int main(void){
   } else {
     printf ("Test Offset: Succeeded\n");
   }
+  any_fail += fail;
 
   // Restore original pointers
   pA = &A[0];
@@ -244,6 +251,7 @@ int main(void){
   } else {
     printf ("Test Offset struct: Succeeded\n");
   }
+  any_fail += fail;
 #endif
 
 #if FP
@@ -266,6 +274,7 @@ int main(void){
   } else {
     printf ("Test first-private: Succeeded\n");
   }
+  any_fail += fail;
 #endif
 
 #if FP_RANGES
@@ -287,6 +296,7 @@ int main(void){
   } else {
     printf ("Test first-private with ranges: Succeeded\n");
   }
+  any_fail += fail;
 #endif
 
 #if FPPTR
@@ -308,6 +318,7 @@ int main(void){
   } else {
     printf ("Test first-private with pointers: Succeeded\n");
   }
+  any_fail += fail;
 #endif
 
 #if DEVICEPTR
@@ -341,6 +352,7 @@ int main(void){
   } else {
     printf ("Test device_ptr: Succeeded\n");
   }
+  any_fail += fail;
 #endif
 
 #if PTR_REF
@@ -369,7 +381,8 @@ int main(void){
   } else {
     printf ("Test refs to ptrs: Succeeded\n");
   }
+  any_fail += fail;
 #endif
 
-  return 0;
+  return any_fail > 0;
 }

--- a/t-target-teams-distribute-simd/test.c
+++ b/t-target-teams-distribute-simd/test.c
@@ -48,7 +48,9 @@ int check_results_priv(double *A, double *B){
   } \
   success += check_results(A); \
   if (success == expected) \
-    printf("Succeeded\n");
+    printf("Succeeded\n"); \
+  else \
+    any_fail += 1;
 
 #define CODE_PRIV() \
   ZERO(A); \
@@ -67,12 +69,15 @@ int check_results_priv(double *A, double *B){
   } \
   success += check_results_priv(A, B); \
   if (success == expected) \
-    printf("Succeeded\n");
+    printf("Succeeded\n"); \
+  else \
+    any_fail += 1;
 
 int main(void) {
   check_offloading();
 
   double A[N], B[N], C[N], D[N], E[N];
+  int any_fail = 0;
   int fail = 0;
   int expected = 1;
   int success = 0;
@@ -199,6 +204,7 @@ int main(void) {
   }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 #endif
 
   //
@@ -220,6 +226,7 @@ int main(void) {
 
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 #endif
 
   // // ***************************
@@ -253,6 +260,7 @@ int main(void) {
 
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: blocking loop where upper bound is not a multiple of tl*nte
@@ -283,6 +291,7 @@ int main(void) {
 
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   // **************************
   // Series 5: collapse
@@ -320,6 +329,7 @@ int main(void) {
       }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: 3 loops
@@ -355,7 +365,8 @@ int main(void) {
         }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
-  return fail;
+  return any_fail > 0;
 }
 

--- a/t-target-teams-distribute/test.c
+++ b/t-target-teams-distribute/test.c
@@ -14,6 +14,7 @@
 #define ZERO(X) ZERO_ARRAY(N, X)
 
 int main(void) {
+  int any_fail = 0;
   check_offloading();
 
   double A[N], B[N], C[N], D[N], E[N];
@@ -43,6 +44,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: #iterations > #teams
@@ -81,6 +83,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   // ****************************
   // Series 2: with dist_schedule
@@ -104,6 +107,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: #iterations == #teams, dist_schedule(#iterations)
@@ -123,6 +127,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: #iterations == #teams, dist_schedule(#iterations/10), variable chunk size
@@ -144,6 +149,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: #iterations > #teams, dist_schedule(1)
@@ -163,6 +169,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: #iterations > #teams, dist_schedule(#iterations)
@@ -182,6 +189,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: #iterations > #teams, dist_schedule(#iterations/10), variable chunk size
@@ -203,6 +211,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: #iterations < #teams, dist_schedule(1)
@@ -222,6 +231,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: #iterations < #teams, dist_schedule(#iterations)
@@ -241,6 +251,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: #iterations < #teams, dist_schedule(#iterations)
@@ -262,6 +273,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   // ****************************
   // Series 3: with ds attributes
@@ -292,6 +304,7 @@ int main(void) {
   }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: firstprivate
@@ -330,6 +343,7 @@ int main(void) {
   }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: lastprivate
@@ -347,6 +361,7 @@ int main(void) {
 
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   // ***************************
   // Series 4: with parallel for
@@ -378,6 +393,7 @@ int main(void) {
 
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: blocking loop where upper bound is not a multiple of tl*nte
@@ -406,6 +422,7 @@ int main(void) {
 
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   // **************************
   // Series 5: collapse
@@ -439,6 +456,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: 3 loops
@@ -470,5 +488,7 @@ int main(void) {
 	}
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
-  return 0;
+  any_fail += fail;
+
+  return any_fail > 0;
 }

--- a/t-target-update/test.c
+++ b/t-target-update/test.c
@@ -20,7 +20,7 @@ int main(void){
 #if CHECK
     check_offloading();
 #endif
-
+  int any_fail = 0;
   int fail;
   double A[N], B[N], C[N], D[N], E[N];
   double *pA, *pB, *pC, *pD, *pE;
@@ -53,6 +53,7 @@ int main(void){
     } else {
       printf ("Test update from: Succeeded\n");
     }
+    any_fail += fail;
 
     // Now modify host arrays C and D
     for(int i = 0; i < N; i++){
@@ -79,6 +80,7 @@ int main(void){
     } else {
       printf ("Test update to: Succeeded\n");
     }
+    any_fail += fail;
   }
 #endif
 
@@ -103,6 +105,7 @@ int main(void){
     } else {
       printf ("Test update from with zero-length ptrs: Succeeded\n");
     }
+    any_fail += fail;
 
     // Now modify host arrays C and D
     for(int i = 0; i < N; i++){
@@ -129,6 +132,7 @@ int main(void){
     } else {
       printf ("Test update to with zero-length ptrs: Succeeded\n");
     }
+    any_fail += fail;
   }
 #endif
 
@@ -158,6 +162,7 @@ int main(void){
     } else {
       printf ("Test update from with offsets: Succeeded\n");
     }
+    any_fail += fail;
 
     // Now modify host arrays C and D
     for(int i = 0; i < N; i++){
@@ -185,8 +190,9 @@ int main(void){
     } else {
       printf ("Test update to with offsets: Succeeded\n");
     }
+    any_fail += fail;
   }
 #endif
 
-  return 0;
+  return any_fail > 0;
 }

--- a/t-task/task.c
+++ b/t-task/task.c
@@ -30,6 +30,7 @@
 
 int main ()
 {
+  int any_errors = 0;
   int a[N], aa[N];
   int b[N], bb[N];
   int c[N], cc[N];
@@ -79,6 +80,7 @@ int main ()
     if (b[i] != bb[i]) printf("%4i: got b %d, expected %d, error %d\n", i, b[i], bb[i], ++errors);
   }
   printf("#1 got %d errors\n", errors);
+  any_errors += errors;
 #endif
 
   // Test: task within parallel
@@ -123,6 +125,7 @@ int main ()
     if (b[i] != bb[i]) printf("%4i: got b %d, expected %d, error %d\n", i, b[i], bb[i], ++errors);
   }
   printf("#2 got %d errors\n", errors);
+  any_errors += errors;
 #endif
 
   // Test: multiple nested tasks in parallel region
@@ -177,6 +180,7 @@ int main ()
     if (b[i] != bb[i]) printf("%4i: got b %d, expected %d, error %d\n", i, b[i], bb[i], ++errors);
   }
   printf("#3 got %d errors\n", errors);
+  any_errors += errors;
 #endif
 
   // Test: three successive tasks in a parallel region
@@ -228,6 +232,7 @@ int main ()
     if (b[i] != bb[i]) printf("%4i: got b %d, expected %d, error %d\n", i, b[i], bb[i], ++errors);
   }
   printf("#4 got %d errors\n", errors);
+  any_errors += errors;
 #endif
 
   // Test: change of context when entering/exiting tasks
@@ -310,6 +315,7 @@ int main ()
   }
 
   printf("#5 got %d errors\n", errors);
+  any_errors += errors;
 #endif
 
   // Test: change of context when using if clause
@@ -392,6 +398,7 @@ int main ()
   }
 
   printf("#6 got %d errors\n", errors);
+  any_errors += errors;
 #endif
 
   // Test: final
@@ -446,6 +453,7 @@ int main ()
     if (b[i] != bb[i]) printf("%4i: got b %d, expected %d, error %d\n", i, b[i], bb[i], ++errors);
   }
   printf("#7 got %d errors\n", errors);
+  any_errors += errors;
 #endif
 
   // Test: untied
@@ -500,6 +508,7 @@ int main ()
     if (b[i] != bb[i]) printf("%4i: got b %d, expected %d, error %d\n", i, b[i], bb[i], ++errors);
   }
   printf("#8 got %d errors\n", errors);
+  any_errors += errors;
 #endif
 
   // Test: mergeaeble
@@ -554,6 +563,7 @@ int main ()
     if (b[i] != bb[i]) printf("%4i: got b %d, expected %d, error %d\n", i, b[i], bb[i], ++errors);
   }
   printf("#9 got %d errors\n", errors);
+  any_errors += errors;
 #endif
 
   // Test: private
@@ -606,6 +616,7 @@ int main ()
     if (b[i] != bb[i]) printf("%4i: got b %d, expected %d, error %d\n", i, b[i], bb[i], ++errors);
   }
   printf("#10 got %d errors\n", errors);
+  any_errors += errors;
 #endif
 
   // Test: depend
@@ -655,6 +666,7 @@ int main ()
     if (b[i] != bb[i]) printf("%4i: got b %d, expected %d, error %d\n", i, b[i], bb[i], ++errors);
   }
   printf("#11 got %d errors\n", errors);
+  any_errors += errors;
 #endif
 
   // Test: inverted priority
@@ -706,7 +718,8 @@ int main ()
     if (b[i] != bb[i]) printf("%4i: got b %d, expected %d, error %d\n", i, b[i], bb[i], ++errors);
   }
   printf("#12 got %d errors\n", errors);
+  any_errors += errors;
 #endif
 
-  return 0;
+  return any_errors > 0;
 }

--- a/t-taskgroup/test.c
+++ b/t-taskgroup/test.c
@@ -74,5 +74,5 @@ int main()
   } else // if !cpuExec
     DUMP_SUCCESS(1);
 
-  return 0;
+  return fail;
 }

--- a/t-taskwait/test.c
+++ b/t-taskwait/test.c
@@ -77,5 +77,5 @@ int main ()
   }
   printf("got %d errors\n", errors);
 
-  return 0;
+  return errors > 0;
 }

--- a/t-taskyield/test.c
+++ b/t-taskyield/test.c
@@ -65,5 +65,5 @@ int main()
     } else // if !cpuExec
     DUMP_SUCCESS(1);
 
-  return 0;
+  return fail;
 }

--- a/t-teams-distribute-simd/test.c
+++ b/t-teams-distribute-simd/test.c
@@ -49,7 +49,9 @@ int check_results_priv(double *A, double *B){
   } \
   success += check_results(A); \
   if (success == expected) \
-    printf("Succeeded\n");
+    printf("Succeeded\n"); \
+  else \
+    any_fail += 1;
 
 #define CODE_PRIV() \
   ZERO(A); \
@@ -69,12 +71,15 @@ int check_results_priv(double *A, double *B){
   } \
   success += check_results_priv(A, B); \
   if (success == expected) \
-    printf("Succeeded\n");
+    printf("Succeeded\n"); \
+  else \
+    any_fail += 1;
 
 int main(void) {
   check_offloading();
 
   double A[N], B[N], C[N], D[N], E[N];
+  int any_fail = 0;
   int fail = 0;
   int expected = 1;
   int success = 0;
@@ -201,6 +206,7 @@ int main(void) {
   }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 #endif
 
   //
@@ -223,6 +229,7 @@ int main(void) {
 
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 #endif
 
   // // ***************************
@@ -257,6 +264,7 @@ int main(void) {
 
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: blocking loop where upper bound is not a multiple of tl*nte
@@ -288,6 +296,7 @@ int main(void) {
 
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   // **************************
   // Series 5: collapse
@@ -325,6 +334,7 @@ int main(void) {
       }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: 3 loops
@@ -360,7 +370,7 @@ int main(void) {
         }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
-  return fail;
+  return any_fail > 0;
 }
-

--- a/t-teams-distribute/test.c
+++ b/t-teams-distribute/test.c
@@ -49,7 +49,9 @@ int check_results_priv(double *A, double *B){
   } \
   success += check_results(A); \
   if (success == expected) \
-    printf("Succeeded\n");
+    printf("Succeeded\n"); \
+  else \
+    any_fail += 1;
 
 #define CODE_PRIV() \
   ZERO(A); \
@@ -69,12 +71,15 @@ int check_results_priv(double *A, double *B){
   } \
   success += check_results_priv(A, B); \
   if (success == expected) \
-    printf("Succeeded\n");
+    printf("Succeeded\n"); \
+  else \
+    any_fail += 1;
 
 int main(void) {
   check_offloading();
 
   double A[N], B[N], C[N], D[N], E[N];
+  int any_fail = 0;
   int fail = 0;
   int expected = 1;
   int success = 0;
@@ -201,6 +206,7 @@ int main(void) {
   }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 #endif
 
   //
@@ -222,6 +228,7 @@ int main(void) {
 
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
 
   // // ***************************
@@ -257,6 +264,7 @@ int main(void) {
 
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: blocking loop where upper bound is not a multiple of tl*nte
@@ -289,6 +297,7 @@ int main(void) {
 
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   // **************************
   // Series 5: collapse
@@ -326,6 +335,7 @@ int main(void) {
       }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: 3 loops
@@ -361,7 +371,8 @@ int main(void) {
         }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
-  return fail;
+  return any_fail > 0;
 }
 

--- a/t-ttdpf-nested-parallel/test.c
+++ b/t-ttdpf-nested-parallel/test.c
@@ -19,6 +19,7 @@ double S[M];
 double p[2];
 
 int main(void) {
+  int any_fail = 0;
   check_offloading();
 
   INIT();
@@ -56,7 +57,7 @@ int main(void) {
     }
     S[idx] += tmp;
   },
-  VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))))
+  {VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))); any_fail += 1;})
   #undef NESTED_PARALLEL_FOR_CLAUSES
   #define NESTED_PARALLEL_FOR_CLAUSES proc_bind(close)
   #include "defines.h"
@@ -76,7 +77,7 @@ int main(void) {
     }
     S[idx] += tmp;
   },
-  VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))))
+  {VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))); any_fail += 1;})
 
   #undef NESTED_PARALLEL_FOR_CLAUSES
   #define NESTED_PARALLEL_FOR_CLAUSES proc_bind(spread)
@@ -97,7 +98,7 @@ int main(void) {
     }
     S[idx] += tmp;
   },
-  VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))))
+  {VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))); any_fail += 1;})
 
   //
   // Test: private, shared clauses on omp target teams distribute parallel for with nested parallel.
@@ -126,7 +127,7 @@ int main(void) {
     }
     S[idx] += tmp;
   },
-  VERIFY(0, tms*th, S[i], (double) 6 + SUMS * (N/2*(N+1))))
+  {VERIFY(0, tms*th, S[i], (double) 6 + SUMS * (N/2*(N+1))); any_fail += 1;})
 
   //
   // Test: firstprivate clause on omp target teams distribute parallel for with nested parallel.
@@ -157,7 +158,7 @@ int main(void) {
     }
     S[idx] += tmp;
   },
-  VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))))
+  {VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))); any_fail += 1;})
 
   //
   // Test: lastprivate clause on omp target teams distribute parallel for with nested parallel.
@@ -198,7 +199,7 @@ int main(void) {
     }
     S[idx] += tmp;
   }
-  , VERIFY(0, tms*th, S[i], (double) 2 * (N + (N/2*(N+1))) ));
+  , {VERIFY(0, tms*th, S[i], (double) 2 * (N + (N/2*(N+1))) ); any_fail += 1;});
 
   //
   // Test: private clause on omp target teams distribute parallel for with nested parallel.
@@ -228,7 +229,7 @@ int main(void) {
     }
     S[idx] += tmp;
   },
-  VERIFY(0, tms*th, S[i], (double) 6 + SUMS * (N/2*(N+1))))
+  {VERIFY(0, tms*th, S[i], (double) 6 + SUMS * (N/2*(N+1))); any_fail += 1;})
 
   //
   // Test: firstprivate clause on omp target teams distribute parallel for with nested parallel.
@@ -260,7 +261,7 @@ int main(void) {
     }
     S[idx] += tmp;
   },
-  VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))))
+  {VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))); any_fail += 1;})
 
   //
   // Test: collapse clause on omp target teams distribute parallel for with nested parallel.
@@ -288,7 +289,7 @@ int main(void) {
     }
     S[idx] += tmp;
   },
-  VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))))
+  {VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))); any_fail += 1;})
 
   //
   // Test: ordered clause on omp target teams distribute parallel for with nested parallel.
@@ -306,7 +307,7 @@ int main(void) {
   ,
   {
   },
-  VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))))
+  {VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))); any_fail += 1;})
 
   //
   // Test: Ensure coalesced scheduling on GPU.
@@ -336,11 +337,11 @@ int main(void) {
         }
         S[idx] = tmp;
       }
-    , VERIFY(0, tms*th, S[i], (double) 3 * 95 * 48 ));
+    , {VERIFY(0, tms*th, S[i], (double) 3 * 95 * 48 ); any_fail += 1;});
   } else {
     DUMP_SUCCESS(1);
   }
   //DUMP_SUCCESS(1);
 
-  return 0;
+  return any_fail > 0;
 }

--- a/t-ttdpfs-nested-parallel/test.c
+++ b/t-ttdpfs-nested-parallel/test.c
@@ -19,6 +19,7 @@ double S[M];
 double p[2];
 
 int main(void) {
+  int any_fail = 0;
   check_offloading();
 
   INIT();
@@ -50,7 +51,7 @@ int main(void) {
     }
     S[idx] += tmp;
   },
-  VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))))
+  {VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))); any_fail += 1;})
 
   #undef NESTED_PARALLEL_FOR_CLAUSES
   #define NESTED_PARALLEL_FOR_CLAUSES proc_bind(close)
@@ -71,7 +72,7 @@ int main(void) {
     }
     S[idx] += tmp;
   },
-  VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))))
+  {VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))); any_fail += 1;})
 
   #undef NESTED_PARALLEL_FOR_CLAUSES
   #define NESTED_PARALLEL_FOR_CLAUSES proc_bind(spread)
@@ -92,7 +93,7 @@ int main(void) {
     }
     S[idx] += tmp;
   },
-  VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))))
+  {VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))); any_fail += 1;})
 
   //
   // Test: private, shared clauses on omp target teams distribute parallel for with nested parallel.
@@ -121,7 +122,7 @@ int main(void) {
     }
     S[idx] += tmp;
   },
-  VERIFY(0, tms*th, S[i], (double) 6 + SUMS * (N/2*(N+1))))
+  {VERIFY(0, tms*th, S[i], (double) 6 + SUMS * (N/2*(N+1))); any_fail += 1;})
 
   //
   // Test: firstprivate clause on omp target teams distribute parallel for with nested parallel.
@@ -152,7 +153,7 @@ int main(void) {
     }
     S[idx] += tmp;
   },
-  VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))))
+  {VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))); any_fail += 1;})
 
   //
   // Test: lastprivate clause on omp target teams distribute parallel for with nested parallel.
@@ -193,7 +194,7 @@ int main(void) {
     }
     S[idx] += tmp;
   }
-  , VERIFY(0, tms*th, S[i], (double) 2 * (N + (N/2*(N+1))) ));
+  , {VERIFY(0, tms*th, S[i], (double) 2 * (N + (N/2*(N+1))) ); any_fail += 1;});
 
   //
   // Test: private clause on omp target teams distribute parallel for with nested parallel.
@@ -223,7 +224,7 @@ int main(void) {
     }
     S[idx] += tmp;
   },
-  VERIFY(0, tms*th, S[i], (double) 6 + SUMS * (N/2*(N+1))))
+  {VERIFY(0, tms*th, S[i], (double) 6 + SUMS * (N/2*(N+1))); any_fail += 1;})
 
   //
   // Test: firstprivate clause on omp target teams distribute parallel for with nested parallel.
@@ -255,7 +256,7 @@ int main(void) {
     }
     S[idx] += tmp;
   },
-  VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))))
+  {VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))); any_fail += 1;})
 
   //
   // Test: collapse clause on omp target teams distribute parallel for with nested parallel.
@@ -283,7 +284,7 @@ int main(void) {
     }
     S[idx] += tmp;
   },
-  VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))))
+  {VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))); any_fail += 1;})
 
   //
   // Test: ordered clause on omp target teams distribute parallel for with nested parallel.
@@ -301,7 +302,7 @@ int main(void) {
   ,
   {
   },
-  VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))))
+  {VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))); any_fail += 1;})
 
-  return 0;
+  return any_fail > 0;
 }

--- a/t-unified-concurrent-target/test.c
+++ b/t-unified-concurrent-target/test.c
@@ -27,6 +27,7 @@ int main(void){
 #endif
 
   int fail;
+  int any_fail = 0;
   double A[N], B[N], C[N], D[N], E[N];
   double *pA, *pB, *pC, *pD, *pE;
   int t;
@@ -57,6 +58,7 @@ int main(void){
   } else {
     printf ("Test PAR_A: Succeeded\n");
   }
+  any_fail += fail;
 #endif
 
 #if PAR_P
@@ -79,6 +81,7 @@ int main(void){
   } else {
     printf ("Test PAR_P: Succeeded\n");
   }
+  any_fail += fail;
 #endif
 
 #if PAR_1_DATA_A
@@ -104,6 +107,7 @@ int main(void){
   } else {
     printf ("Test PAR_1_DATA_A: Succeeded\n");
   }
+  any_fail += fail;
 #endif
 
 #if PAR_T_DATA_A
@@ -130,6 +134,7 @@ int main(void){
   } else {
     printf ("Test PAR_T_DATA_A: Succeeded\n");
   }
+  any_fail += fail;
 #endif
 
 #if PAR_TOFROM_A
@@ -152,6 +157,7 @@ int main(void){
   } else {
     printf ("Test PAR_TOFROM_A: Succeeded\n");
   }
+  any_fail += fail;
 #endif
 
 #if PAR_TOALL_FROM_A  
@@ -175,7 +181,8 @@ int main(void){
   } else {
     printf ("Test PAR_TOALL_FROM_A: Succeeded\n");
   }
+  any_fail += fail;
 #endif
 
-  return 0;
+  return any_fail > 0;
 }

--- a/t-unified-critical/test.c
+++ b/t-unified-critical/test.c
@@ -14,6 +14,7 @@ const int Y_VAL = 11;
 
 int main()
 {
+  int any_failures = 0;
   check_offloading();
 
   long cpuExec = 0;
@@ -58,6 +59,7 @@ int main()
       printf("failed %d times\n", failures);
     else
       printf("Succeeded\n");
+    any_failures += failures;
 
     /// Test team-level dependencies with increment
 #pragma omp target map(tofrom: x[:nb], y[:nb])
@@ -83,10 +85,9 @@ int main()
       printf("failed %d times\n", failures);
     else
       printf("Succeeded\n");
-    return failures;
+    any_failures += failures;
   } else {// if !cpuExec
     DUMP_SUCCESS(2);
-    return 0;
   }
+  return any_failures > 0;
 }
-

--- a/t-unified-data-sharing-many-teams/test.cpp
+++ b/t-unified-data-sharing-many-teams/test.cpp
@@ -8,6 +8,8 @@
 #define Arr(x,i,j,k) ((x)[(i)*(I)*(I) + (j)*(I) + (k)])
 #define TEAM_SIZE 8096
 
+static int any_error = 0;
+
 template<const unsigned I, const unsigned P1, const unsigned P2>
 void foo_device_parallel(unsigned ii, unsigned *ReferenceA, unsigned *ReferenceB) {
   printf("Running device version - parallel...\n");
@@ -66,6 +68,7 @@ void foo_device_parallel(unsigned ii, unsigned *ReferenceA, unsigned *ReferenceB
   for(unsigned i = 0; i<I*I*I; ++i) {
     if (A[i] != B[i]) {
       printf("Error (device) A[i] != B[i] at %08x: %08x != %08x\n", i, A[i], B[i]);
+      any_error = 1;
       break;
     }
   }
@@ -74,6 +77,7 @@ void foo_device_parallel(unsigned ii, unsigned *ReferenceA, unsigned *ReferenceB
     for(unsigned i = 0; i<I*I*I; ++i)
       if (A[i] != ReferenceA[i]) {
         printf("Error A[i] != ReferenceA[i] at %08x: %08x != %08x\n", i, A[i], ReferenceA[i]);
+        any_error = 1;
         break;
       }
     
@@ -81,6 +85,7 @@ void foo_device_parallel(unsigned ii, unsigned *ReferenceA, unsigned *ReferenceB
     for(unsigned i = 0; i<I*I*I; ++i)
       if (B[i] != ReferenceB[i]) {
         printf("Error B[i] != ReferenceB[i] at %08x: %08x != %08x\n", i, B[i], ReferenceB[i]);
+        any_error = 1;
         break;
       }
 
@@ -143,6 +148,7 @@ void foo_device_parallel_parallel(unsigned ii, unsigned *ReferenceA, unsigned *R
   for(unsigned i = 0; i<I*I*I; ++i) {
     if (A[i] != B[i]) {
       printf("Error (device) A[i] != B[i] at %08x: %08x != %08x\n", i, A[i], B[i]);
+      any_error = 1;
       break;
     }
   }
@@ -151,6 +157,7 @@ void foo_device_parallel_parallel(unsigned ii, unsigned *ReferenceA, unsigned *R
     for(unsigned i = 0; i<I*I*I; ++i)
       if (A[i] != ReferenceA[i]) {
         printf("Error A[i] != ReferenceA[i] at %08x: %08x != %08x\n", i, A[i], ReferenceA[i]);
+        any_error = 1;
         break;
       }
     
@@ -158,6 +165,7 @@ void foo_device_parallel_parallel(unsigned ii, unsigned *ReferenceA, unsigned *R
     for(unsigned i = 0; i<I*I*I; ++i)
       if (B[i] != ReferenceB[i]) {
         printf("Error B[i] != ReferenceB[i] at %08x: %08x != %08x\n", i, B[i], ReferenceB[i]);
+        any_error = 1;
         break;
       }
 
@@ -220,6 +228,7 @@ void foo_device_simd(unsigned ii, unsigned *ReferenceA, unsigned *ReferenceB) {
   for(unsigned i = 0; i<I*I*I; ++i) {
     if (A[i] != B[i]) {
       printf("Error (device) A[i] != B[i] at %08x: %08x != %08x\n", i, A[i], B[i]);
+      any_error = 1;
       break;
     }
   }
@@ -228,6 +237,7 @@ void foo_device_simd(unsigned ii, unsigned *ReferenceA, unsigned *ReferenceB) {
     for(unsigned i = 0; i<I*I*I; ++i)
       if (A[i] != ReferenceA[i]) {
         printf("Error A[i] != ReferenceA[i] at %08x: %08x != %08x\n", i, A[i], ReferenceA[i]);
+        any_error = 1;
         break;
       }
     
@@ -235,6 +245,7 @@ void foo_device_simd(unsigned ii, unsigned *ReferenceA, unsigned *ReferenceB) {
     for(unsigned i = 0; i<I*I*I; ++i)
       if (B[i] != ReferenceB[i]) {
         printf("Error B[i] != ReferenceB[i] at %08x: %08x != %08x\n", i, B[i], ReferenceB[i]);
+        any_error = 1;
         break;
       }
 
@@ -299,6 +310,7 @@ void foo_device_parallel_simd(unsigned ii, unsigned *ReferenceA, unsigned *Refer
   for(unsigned i = 0; i<I*I*I; ++i) {
     if (A[i] != B[i]) {
       printf("Error (device) A[i] != B[i] at %08x: %08x != %08x\n", i, A[i], B[i]);
+      any_error = 1;
       break;
     }
   }
@@ -307,6 +319,7 @@ void foo_device_parallel_simd(unsigned ii, unsigned *ReferenceA, unsigned *Refer
     for(unsigned i = 0; i<I*I*I; ++i)
       if (A[i] != ReferenceA[i]) {
         printf("Error A[i] != ReferenceA[i] at %08x: %08x != %08x\n", i, A[i], ReferenceA[i]);
+        any_error = 1;
         break;
       }
     
@@ -314,6 +327,7 @@ void foo_device_parallel_simd(unsigned ii, unsigned *ReferenceA, unsigned *Refer
     for(unsigned i = 0; i<I*I*I; ++i)
       if (B[i] != ReferenceB[i]) {
         printf("Error B[i] != ReferenceB[i] at %08x: %08x != %08x\n", i, B[i], ReferenceB[i]);
+        any_error = 1;
         break;
       }
 
@@ -370,6 +384,7 @@ void foo(unsigned ii) {
   for(unsigned i = 0; i<I*I*I; ++i) {
     if (A[i] != B[i]) {
       printf("Error (host) A[i] != B[i] at %08x: %08x != %08x\n", i, A[i], B[i]);
+      any_error = 1;
       break;
     }
   }
@@ -446,6 +461,7 @@ void foo_ptr_device_parallel(unsigned ii, unsigned *ReferenceA, unsigned *Refere
     for(unsigned i = 0; i<I*I*I; ++i)
       if (A[i] != ReferenceA[i]) {
         printf("Error A[i] != ReferenceA[i] at %08x: %08x != %08x\n", i, A[i], ReferenceA[i]);
+        any_error = 1;
         break;
       }
     
@@ -453,6 +469,7 @@ void foo_ptr_device_parallel(unsigned ii, unsigned *ReferenceA, unsigned *Refere
     for(unsigned i = 0; i<I*I*I; ++i)
       if (B[i] != ReferenceB[i]) {
         printf("Error B[i] != ReferenceB[i] at %08x: %08x != %08x\n", i, B[i], ReferenceB[i]);
+        any_error = 1;
         break;
       }
 
@@ -515,6 +532,7 @@ void foo_ptr_device_parallel_parallel(unsigned ii, unsigned *ReferenceA, unsigne
   for(unsigned i = 0; i<I*I*I; ++i) {
     if (A[i] != B[i]) {
       printf("Error (device) A[i] != B[i] at %08x: %08x != %08x\n", i, A[i], B[i]);
+      any_error = 1;
       break;
     }
   }
@@ -523,6 +541,7 @@ void foo_ptr_device_parallel_parallel(unsigned ii, unsigned *ReferenceA, unsigne
     for(unsigned i = 0; i<I*I*I; ++i)
       if (A[i] != ReferenceA[i]) {
         printf("Error A[i] != ReferenceA[i] at %08x: %08x != %08x\n", i, A[i], ReferenceA[i]);
+        any_error = 1;
         break;
       }
     
@@ -530,6 +549,7 @@ void foo_ptr_device_parallel_parallel(unsigned ii, unsigned *ReferenceA, unsigne
     for(unsigned i = 0; i<I*I*I; ++i)
       if (B[i] != ReferenceB[i]) {
         printf("Error B[i] != ReferenceB[i] at %08x: %08x != %08x\n", i, B[i], ReferenceB[i]);
+        any_error = 1;
         break;
       }
 
@@ -592,6 +612,7 @@ void foo_ptr_device_simd(unsigned ii, unsigned *ReferenceA, unsigned *ReferenceB
   for(unsigned i = 0; i<I*I*I; ++i) {
     if (A[i] != B[i]) {
       printf("Error (device) A[i] != B[i] at %08x: %08x != %08x\n", i, A[i], B[i]);
+      any_error = 1;
       break;
     }
   }
@@ -600,6 +621,7 @@ void foo_ptr_device_simd(unsigned ii, unsigned *ReferenceA, unsigned *ReferenceB
     for(unsigned i = 0; i<I*I*I; ++i)
       if (A[i] != ReferenceA[i]) {
         printf("Error A[i] != ReferenceA[i] at %08x: %08x != %08x\n", i, A[i], ReferenceA[i]);
+        any_error = 1;
         break;
       }
     
@@ -607,6 +629,7 @@ void foo_ptr_device_simd(unsigned ii, unsigned *ReferenceA, unsigned *ReferenceB
     for(unsigned i = 0; i<I*I*I; ++i)
       if (B[i] != ReferenceB[i]) {
         printf("Error B[i] != ReferenceB[i] at %08x: %08x != %08x\n", i, B[i], ReferenceB[i]);
+        any_error = 1;
         break;
       }
 
@@ -671,6 +694,7 @@ void foo_ptr_device_parallel_simd(unsigned ii, unsigned *ReferenceA, unsigned *R
   for(unsigned i = 0; i<I*I*I; ++i) {
     if (A[i] != B[i]) {
       printf("Error (device) A[i] != B[i] at %08x: %08x != %08x\n", i, A[i], B[i]);
+      any_error = 1;
       break;
     }
   }
@@ -679,6 +703,7 @@ void foo_ptr_device_parallel_simd(unsigned ii, unsigned *ReferenceA, unsigned *R
     for(unsigned i = 0; i<I*I*I; ++i)
       if (A[i] != ReferenceA[i]) {
         printf("Error A[i] != ReferenceA[i] at %08x: %08x != %08x\n", i, A[i], ReferenceA[i]);
+        any_error = 1;
         break;
       }
     
@@ -686,6 +711,7 @@ void foo_ptr_device_parallel_simd(unsigned ii, unsigned *ReferenceA, unsigned *R
     for(unsigned i = 0; i<I*I*I; ++i)
       if (B[i] != ReferenceB[i]) {
         printf("Error B[i] != ReferenceB[i] at %08x: %08x != %08x\n", i, B[i], ReferenceB[i]);
+        any_error = 1;
         break;
       }
 
@@ -743,6 +769,7 @@ void foo_ptr(unsigned ii) {
   for(unsigned i = 0; i<I*I*I; ++i) {
     if (A[i] != B[i]) {
       printf("Error (host) A[i] != B[i] at %08x: %08x != %08x\n", i, A[i], B[i]);
+      any_error = 1;
       break;
     }
   }
@@ -842,5 +869,5 @@ int main(void) {
   static_data_sharing();
 
   printf("End!\n");
-  return 0;
+  return any_error;
 }

--- a/t-unified-data-sharing/test.cpp
+++ b/t-unified-data-sharing/test.cpp
@@ -7,6 +7,8 @@
 
 #define Arr(x,i,j,k) ((x)[(i)*(I)*(I) + (j)*(I) + (k)])
 
+static int any_error = 0;
+
 template<const unsigned I, const unsigned P1, const unsigned P2>
 void foo_device_parallel(unsigned ii, unsigned *ReferenceA, unsigned *ReferenceB) {
   printf("Running device version - parallel...\n");
@@ -65,6 +67,7 @@ void foo_device_parallel(unsigned ii, unsigned *ReferenceA, unsigned *ReferenceB
   for(unsigned i = 0; i<I*I*I; ++i) {
     if (A[i] != B[i]) {
       printf("Error (device) A[i] != B[i] at %08x: %08x != %08x\n", i, A[i], B[i]);
+      any_error = 1;
       break;
     }
   }
@@ -73,6 +76,7 @@ void foo_device_parallel(unsigned ii, unsigned *ReferenceA, unsigned *ReferenceB
     for(unsigned i = 0; i<I*I*I; ++i)
       if (A[i] != ReferenceA[i]) {
         printf("Error A[i] != ReferenceA[i] at %08x: %08x != %08x\n", i, A[i], ReferenceA[i]);
+        any_error = 1;
         break;
       }
     
@@ -80,6 +84,7 @@ void foo_device_parallel(unsigned ii, unsigned *ReferenceA, unsigned *ReferenceB
     for(unsigned i = 0; i<I*I*I; ++i)
       if (B[i] != ReferenceB[i]) {
         printf("Error B[i] != ReferenceB[i] at %08x: %08x != %08x\n", i, B[i], ReferenceB[i]);
+        any_error = 1;
         break;
       }
 
@@ -142,6 +147,7 @@ void foo_device_parallel_parallel(unsigned ii, unsigned *ReferenceA, unsigned *R
   for(unsigned i = 0; i<I*I*I; ++i) {
     if (A[i] != B[i]) {
       printf("Error (device) A[i] != B[i] at %08x: %08x != %08x\n", i, A[i], B[i]);
+      any_error = 1;
       break;
     }
   }
@@ -150,6 +156,7 @@ void foo_device_parallel_parallel(unsigned ii, unsigned *ReferenceA, unsigned *R
     for(unsigned i = 0; i<I*I*I; ++i)
       if (A[i] != ReferenceA[i]) {
         printf("Error A[i] != ReferenceA[i] at %08x: %08x != %08x\n", i, A[i], ReferenceA[i]);
+        any_error = 1;
         break;
       }
     
@@ -157,6 +164,7 @@ void foo_device_parallel_parallel(unsigned ii, unsigned *ReferenceA, unsigned *R
     for(unsigned i = 0; i<I*I*I; ++i)
       if (B[i] != ReferenceB[i]) {
         printf("Error B[i] != ReferenceB[i] at %08x: %08x != %08x\n", i, B[i], ReferenceB[i]);
+        any_error = 1;
         break;
       }
 
@@ -219,6 +227,7 @@ void foo_device_simd(unsigned ii, unsigned *ReferenceA, unsigned *ReferenceB) {
   for(unsigned i = 0; i<I*I*I; ++i) {
     if (A[i] != B[i]) {
       printf("Error (device) A[i] != B[i] at %08x: %08x != %08x\n", i, A[i], B[i]);
+      any_error = 1;
       break;
     }
   }
@@ -227,6 +236,7 @@ void foo_device_simd(unsigned ii, unsigned *ReferenceA, unsigned *ReferenceB) {
     for(unsigned i = 0; i<I*I*I; ++i)
       if (A[i] != ReferenceA[i]) {
         printf("Error A[i] != ReferenceA[i] at %08x: %08x != %08x\n", i, A[i], ReferenceA[i]);
+        any_error = 1;
         break;
       }
     
@@ -234,6 +244,7 @@ void foo_device_simd(unsigned ii, unsigned *ReferenceA, unsigned *ReferenceB) {
     for(unsigned i = 0; i<I*I*I; ++i)
       if (B[i] != ReferenceB[i]) {
         printf("Error B[i] != ReferenceB[i] at %08x: %08x != %08x\n", i, B[i], ReferenceB[i]);
+        any_error = 1;
         break;
       }
 
@@ -298,6 +309,7 @@ void foo_device_parallel_simd(unsigned ii, unsigned *ReferenceA, unsigned *Refer
   for(unsigned i = 0; i<I*I*I; ++i) {
     if (A[i] != B[i]) {
       printf("Error (device) A[i] != B[i] at %08x: %08x != %08x\n", i, A[i], B[i]);
+      any_error = 1;
       break;
     }
   }
@@ -306,6 +318,7 @@ void foo_device_parallel_simd(unsigned ii, unsigned *ReferenceA, unsigned *Refer
     for(unsigned i = 0; i<I*I*I; ++i)
       if (A[i] != ReferenceA[i]) {
         printf("Error A[i] != ReferenceA[i] at %08x: %08x != %08x\n", i, A[i], ReferenceA[i]);
+        any_error = 1;
         break;
       }
     
@@ -313,6 +326,7 @@ void foo_device_parallel_simd(unsigned ii, unsigned *ReferenceA, unsigned *Refer
     for(unsigned i = 0; i<I*I*I; ++i)
       if (B[i] != ReferenceB[i]) {
         printf("Error B[i] != ReferenceB[i] at %08x: %08x != %08x\n", i, B[i], ReferenceB[i]);
+        any_error = 1;
         break;
       }
 
@@ -369,6 +383,7 @@ void foo(unsigned ii) {
   for(unsigned i = 0; i<I*I*I; ++i) {
     if (A[i] != B[i]) {
       printf("Error (host) A[i] != B[i] at %08x: %08x != %08x\n", i, A[i], B[i]);
+      any_error = 1;
       break;
     }
   }
@@ -437,6 +452,7 @@ void foo_ptr_device_parallel(unsigned ii, unsigned *ReferenceA, unsigned *Refere
   for(unsigned i = 0; i<I*I*I; ++i) {
     if (A[i] != B[i]) {
       printf("Error (device) A[i] != B[i] at %08x: %08x != %08x\n", i, A[i], B[i]);
+      any_error = 1;
       break;
     }
   }
@@ -445,6 +461,7 @@ void foo_ptr_device_parallel(unsigned ii, unsigned *ReferenceA, unsigned *Refere
     for(unsigned i = 0; i<I*I*I; ++i)
       if (A[i] != ReferenceA[i]) {
         printf("Error A[i] != ReferenceA[i] at %08x: %08x != %08x\n", i, A[i], ReferenceA[i]);
+        any_error = 1;
         break;
       }
     
@@ -452,6 +469,7 @@ void foo_ptr_device_parallel(unsigned ii, unsigned *ReferenceA, unsigned *Refere
     for(unsigned i = 0; i<I*I*I; ++i)
       if (B[i] != ReferenceB[i]) {
         printf("Error B[i] != ReferenceB[i] at %08x: %08x != %08x\n", i, B[i], ReferenceB[i]);
+        any_error = 1;
         break;
       }
 
@@ -514,6 +532,7 @@ void foo_ptr_device_parallel_parallel(unsigned ii, unsigned *ReferenceA, unsigne
   for(unsigned i = 0; i<I*I*I; ++i) {
     if (A[i] != B[i]) {
       printf("Error (device) A[i] != B[i] at %08x: %08x != %08x\n", i, A[i], B[i]);
+      any_error = 1;
       break;
     }
   }
@@ -522,6 +541,7 @@ void foo_ptr_device_parallel_parallel(unsigned ii, unsigned *ReferenceA, unsigne
     for(unsigned i = 0; i<I*I*I; ++i)
       if (A[i] != ReferenceA[i]) {
         printf("Error A[i] != ReferenceA[i] at %08x: %08x != %08x\n", i, A[i], ReferenceA[i]);
+        any_error = 1;
         break;
       }
     
@@ -529,6 +549,7 @@ void foo_ptr_device_parallel_parallel(unsigned ii, unsigned *ReferenceA, unsigne
     for(unsigned i = 0; i<I*I*I; ++i)
       if (B[i] != ReferenceB[i]) {
         printf("Error B[i] != ReferenceB[i] at %08x: %08x != %08x\n", i, B[i], ReferenceB[i]);
+        any_error = 1;
         break;
       }
 
@@ -591,6 +612,7 @@ void foo_ptr_device_simd(unsigned ii, unsigned *ReferenceA, unsigned *ReferenceB
   for(unsigned i = 0; i<I*I*I; ++i) {
     if (A[i] != B[i]) {
       printf("Error (device) A[i] != B[i] at %08x: %08x != %08x\n", i, A[i], B[i]);
+      any_error = 1;
       break;
     }
   }
@@ -599,6 +621,7 @@ void foo_ptr_device_simd(unsigned ii, unsigned *ReferenceA, unsigned *ReferenceB
     for(unsigned i = 0; i<I*I*I; ++i)
       if (A[i] != ReferenceA[i]) {
         printf("Error A[i] != ReferenceA[i] at %08x: %08x != %08x\n", i, A[i], ReferenceA[i]);
+        any_error = 1;
         break;
       }
     
@@ -606,6 +629,7 @@ void foo_ptr_device_simd(unsigned ii, unsigned *ReferenceA, unsigned *ReferenceB
     for(unsigned i = 0; i<I*I*I; ++i)
       if (B[i] != ReferenceB[i]) {
         printf("Error B[i] != ReferenceB[i] at %08x: %08x != %08x\n", i, B[i], ReferenceB[i]);
+        any_error = 1;
         break;
       }
 
@@ -670,6 +694,7 @@ void foo_ptr_device_parallel_simd(unsigned ii, unsigned *ReferenceA, unsigned *R
   for(unsigned i = 0; i<I*I*I; ++i) {
     if (A[i] != B[i]) {
       printf("Error (device) A[i] != B[i] at %08x: %08x != %08x\n", i, A[i], B[i]);
+      any_error = 1;
       break;
     }
   }
@@ -678,6 +703,7 @@ void foo_ptr_device_parallel_simd(unsigned ii, unsigned *ReferenceA, unsigned *R
     for(unsigned i = 0; i<I*I*I; ++i)
       if (A[i] != ReferenceA[i]) {
         printf("Error A[i] != ReferenceA[i] at %08x: %08x != %08x\n", i, A[i], ReferenceA[i]);
+        any_error = 1;
         break;
       }
     
@@ -685,6 +711,7 @@ void foo_ptr_device_parallel_simd(unsigned ii, unsigned *ReferenceA, unsigned *R
     for(unsigned i = 0; i<I*I*I; ++i)
       if (B[i] != ReferenceB[i]) {
         printf("Error B[i] != ReferenceB[i] at %08x: %08x != %08x\n", i, B[i], ReferenceB[i]);
+        any_error = 1;
         break;
       }
 
@@ -742,6 +769,7 @@ void foo_ptr(unsigned ii) {
   for(unsigned i = 0; i<I*I*I; ++i) {
     if (A[i] != B[i]) {
       printf("Error (host) A[i] != B[i] at %08x: %08x != %08x\n", i, A[i], B[i]);
+      any_error = 1;
       break;
     }
   }
@@ -841,5 +869,5 @@ int main(void) {
   static_data_sharing();
 
   printf("End!\n");
-  return 0;
+  return any_error;
 }

--- a/t-unified-declare-simd/test.c
+++ b/t-unified-declare-simd/test.c
@@ -47,6 +47,7 @@ int foo_notinbranch(int *b, int c) {
 
 int main()
 {
+  int any_fail = 0;
   check_offloading();
 
   int a[N], aa[N], b[N];
@@ -84,6 +85,7 @@ int main()
     printf("failed\n");
   else
     printf("success\n");
+  any_fail += fail;
 
   /// Test: simdlen
   fail = 0;
@@ -118,6 +120,7 @@ int main()
     printf("failed\n");
   else
     printf("success\n");
+  any_fail += fail;
 
   /// Test: linear
   fail = 0;
@@ -155,6 +158,7 @@ int main()
     printf("failed\n");
   else
     printf("success\n");
+  any_fail += fail;
 
   /// Test: aligned
   fail = 0;
@@ -192,6 +196,7 @@ int main()
     printf("failed\n");
   else
     printf("success\n");
+  any_fail += fail;
 
   /// Test: uniform
   fail = 0;
@@ -230,6 +235,7 @@ int main()
     printf("failed\n");
   else
     printf("success\n");
+  any_fail += fail;
 
   /// Test: inbranch
   fail = 0;
@@ -270,6 +276,7 @@ int main()
     printf("failed\n");
   else
     printf("success\n");
+  any_fail += fail;
 
   /// Test: notinbranch
   fail = 0;
@@ -308,6 +315,7 @@ int main()
     printf("failed\n");
   else
     printf("success\n");
+  any_fail += fail;
 
-  return 0;
+  return any_fail > 0;
 }

--- a/t-unified-declare-target/test.cpp
+++ b/t-unified-declare-target/test.cpp
@@ -35,7 +35,7 @@ int t1_G1 = 2;
 
 int t1_G2 = 3;
 
-void t1(int a /* = 1 */) {
+int t1(int a /* = 1 */) {
   int A[1] = {0};
 
   #pragma omp target
@@ -49,6 +49,7 @@ void t1(int a /* = 1 */) {
     printf("Error %d != %d\n",A[0], Expected);
   else
     printf("Success!\n");
+  return A[0] != Expected;
 }
 
 //#######################################
@@ -76,7 +77,7 @@ struct t2_d2 {
 
 #pragma omp end declare target
 
-void t2(int a /* = 1 */) {
+int t2(int a /* = 1 */) {
   t2_d1 A;
   t2_d2<int> B;
   
@@ -96,6 +97,7 @@ void t2(int a /* = 1 */) {
     printf("Error %d != %d\n",A.Val, Expected);
   else
     printf("Success!\n");
+  return A.Val != Expected;
 }
 
 //#######################################
@@ -103,12 +105,12 @@ void t2(int a /* = 1 */) {
 //#######################################
 
 int main(int argc, char *argv[]) {
+  int fail = 0;
   check_offloading();
   
-  t1(argc ? 1 : 5);
-  t2(argc ? 1 : 5);
+  fail += t1(argc ? 1 : 5);
+  fail += t2(argc ? 1 : 5);
   
   printf("Done!\n");
-  return 0;
+  return fail > 0;
 }
-

--- a/t-unified-distribute-simd/test.c
+++ b/t-unified-distribute-simd/test.c
@@ -36,11 +36,11 @@ int main()
       printf("%d: a %d != %d (error %d)\n", i, a[i], aa[i], ++error);
     if (error > 10) {
       printf("abort\n");
-      return 0;
+      return 1;
     }
   }
 
   // report
   printf("done with %d errors\n", error);
-  return error;
+  return error > 0;
 }

--- a/t-unified-distribute/test.c
+++ b/t-unified-distribute/test.c
@@ -16,6 +16,7 @@
 #define ZERO(X) ZERO_ARRAY(N, X)
 
 int main(void) {
+  int any_fail = 0;
   check_offloading();
 
   double A[N], B[N], C[N], D[N], E[N];
@@ -47,6 +48,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: #iterations > #teams
@@ -68,6 +70,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: #iterations < #teams
@@ -89,6 +92,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   // ****************************
   // Series 2: with dist_schedule
@@ -114,6 +118,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: #iterations == #teams, dist_schedule(#iterations)
@@ -135,6 +140,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: #iterations == #teams, dist_schedule(#iterations/10), variable chunk size
@@ -158,6 +164,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: #iterations > #teams, dist_schedule(1)
@@ -179,6 +186,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: #iterations > #teams, dist_schedule(#iterations)
@@ -200,6 +208,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: #iterations > #teams, dist_schedule(#iterations/10), variable chunk size
@@ -223,6 +232,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: #iterations < #teams, dist_schedule(1)
@@ -244,6 +254,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: #iterations < #teams, dist_schedule(#iterations)
@@ -265,6 +276,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: #iterations < #teams, dist_schedule(#iterations)
@@ -288,6 +300,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   // ****************************
   // Series 3: with ds attributes
@@ -323,6 +336,7 @@ int main(void) {
   }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: firstprivate
@@ -365,6 +379,7 @@ int main(void) {
   }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: lastprivate
@@ -384,6 +399,7 @@ int main(void) {
 
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
 
   // ***************************
@@ -420,6 +436,7 @@ int main(void) {
 
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: blocking loop where upper bound is not a multiple of tl*nte
@@ -452,6 +469,7 @@ int main(void) {
 
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   // **************************
   // Series 5: collapse
@@ -487,6 +505,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: 3 loops
@@ -520,7 +539,8 @@ int main(void) {
 	}
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
-  return 0;
+  return any_fail > 0;
 }
 

--- a/t-unified-exceptions/test.cpp
+++ b/t-unified-exceptions/test.cpp
@@ -28,5 +28,5 @@ int main(void) {
   ++A[0];
 
   printf("Got %d, should be 3\n", A[0]);
-  return 0;
+  return 3 != A[0];
 }

--- a/t-unified-large-args/test.c
+++ b/t-unified-large-args/test.c
@@ -27,6 +27,7 @@
 #define SUM400 SUM200 + SUM100(2) + SUM100(3)
 
 int main(void) {
+  int any_fail = 0;
   check_offloading();
 
   double A[N], B[N], C[N], D[N], E[N];
@@ -63,7 +64,7 @@ int main(void) {
    for (int i = 0; i < 1024; i++) {
      A[i] += SUM10(00);
    }
-  }, VERIFY(0, 1024, A[i], 70 ));
+  }, {VERIFY(0, 1024, A[i], 70 ); any_fail += fail;});
 
-  return 0;
+  return any_fail > 0;
 }

--- a/t-unified-master/test.c
+++ b/t-unified-master/test.c
@@ -16,6 +16,7 @@
 #define ZERO(X) ZERO_ARRAY(N, X) 
 
 int main(void) {
+  int any_fail = 0;
   check_offloading();
 
   double A[N], B[N], C[N], D[N], E[N];
@@ -50,8 +51,8 @@ int main(void) {
           B[i] += A[i];
         }
       }
-    }, VERIFY(0, N, B[i], 3*i+2));
+    }, {VERIFY(0, N, B[i], 3*i+2); any_fail += fail;});
   }
 
-  return 0;
+  return any_fail > 0;
 }

--- a/t-unified-multiple-compilation-units/omptests.c
+++ b/t-unified-multiple-compilation-units/omptests.c
@@ -26,7 +26,7 @@ int main()
   }
   
   printf("--> %s <--\n",(res < 90.001 && res > 89.999) ? "success" : "error");
-  return 0;
+  return !(res < 90.001 && res > 89.999);
 }
 
 /// Presumably creates an .omp_offloading.entry

--- a/t-unified-parallel-for-simd/test.c
+++ b/t-unified-parallel-for-simd/test.c
@@ -16,6 +16,7 @@
 #define ZERO(X) ZERO_ARRAY(N, X) 
 
 int main(void) {
+  int any_fail = 0;
   check_offloading();
 
   double A[N], B[N], C[N], D[N], E[N];
@@ -53,7 +54,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))); any_fail += fail;})
   }
   printf("B\n");
   #undef PARALLEL_FOR_CLAUSES
@@ -79,7 +80,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))); any_fail += fail;})
   }
   printf("C\n");
   #undef PARALLEL_FOR_CLAUSES
@@ -105,7 +106,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))); any_fail += fail;})
   }
   printf("D\n");
   #undef PARALLEL_FOR_CLAUSES
@@ -131,7 +132,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))); any_fail += fail;})
   }
 
   //
@@ -165,7 +166,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], 6 + SUMS * (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], 6 + SUMS * (N/2*(N+1))); any_fail += fail;})
   }
 
   //
@@ -201,7 +202,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))); any_fail += fail;})
   }
 
   //
@@ -272,7 +273,7 @@ int main(void) {
         tmp += A[i] + B[i];
       }
       S[0] += tmp;
-    }, VERIFY(0, 1, S[0], 5 * (N + (N/2*(N+1))) ));
+    }, {VERIFY(0, 1, S[0], 5 * (N + (N/2*(N+1)))); any_fail += fail;} );
   }
 
   //
@@ -305,7 +306,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], 6 + SUMS * (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], 6 + SUMS * (N/2*(N+1))); any_fail += fail;})
   }
 
   //
@@ -341,7 +342,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))); any_fail += fail;})
   }
 
   //
@@ -373,7 +374,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))); any_fail += fail;})
   }
 
   //
@@ -405,7 +406,7 @@ int main(void) {
         tmp += A[i];
       }
       S[0] = tmp;
-    }, VERIFY(0, 1, S[0], 3 * (33*33 + 66*33) ));
+    }, {VERIFY(0, 1, S[0], 3 * (33*33 + 66*33) ); any_fail += fail;});
   }
 
   //
@@ -435,7 +436,7 @@ int main(void) {
     for(int i=0; i<N; i++)
       aa[i] += i * SUMS;
   },
-  VERIFY_ARRAY(0, N, aa, a));
+  {VERIFY_ARRAY(0, N, aa, a); any_fail += fail;});
 
   //
   // Test: lastprivate clause on omp parallel for.
@@ -463,7 +464,7 @@ int main(void) {
       aa[i] += i * SUMS;
     aa[0] += SUMS * (N - 1);
   },
-  VERIFY_ARRAY(0, N, aa, a));
+  {VERIFY_ARRAY(0, N, aa, a); any_fail += fail;});
 
   //
   // Test: lastprivate clause on omp parallel for.
@@ -489,7 +490,7 @@ int main(void) {
     for(int i=0; i<N; i++)
       aa[i] += 2 * i * SUMS;
   },
-  VERIFY_ARRAY(0, N, aa, a));
+  {VERIFY_ARRAY(0, N, aa, a); any_fail += fail;});
 
   //
   // Test: lastprivate clause on omp parallel for.
@@ -515,7 +516,7 @@ int main(void) {
     for(int i=0; i<N; i++)
       aa[i] += i * SUMS;
   },
-  VERIFY_ARRAY(0, N, aa, a));
+  {VERIFY_ARRAY(0, N, aa, a); any_fail += fail;});
 
   //
   // Test: safelen clause on omp parallel for.
@@ -542,7 +543,7 @@ int main(void) {
     for(int i=0; i<N; i++)
       aa[i] = i;
   },
-  VERIFY_ARRAY(0, N, aa, a));
+  {VERIFY_ARRAY(0, N, aa, a); any_fail += fail;});
 
-  return 0;
+  return any_fail > 0;
 }

--- a/t-unified-parallel-for/test.c
+++ b/t-unified-parallel-for/test.c
@@ -16,6 +16,7 @@
 #define ZERO(X) ZERO_ARRAY(N, X) 
 
 int main(void) {
+  int any_fail = 0;
   check_offloading();
 
   double A[N], B[N], C[N], D[N], E[N];
@@ -51,7 +52,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))); any_fail += fail;})
   }
   printf("B\n");
   #undef PARALLEL_FOR_CLAUSES
@@ -77,7 +78,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))); any_fail += fail;})
   }
   printf("C\n");
   #undef PARALLEL_FOR_CLAUSES
@@ -103,7 +104,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))); any_fail += fail;})
   }
   printf("D\n");
   #undef PARALLEL_FOR_CLAUSES
@@ -129,7 +130,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))); any_fail += fail;})
   }
 
   //
@@ -163,7 +164,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], 6 + SUMS * (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], 6 + SUMS * (N/2*(N+1))); any_fail += fail;})
   }
 
   //
@@ -199,7 +200,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))); any_fail += fail;})
   }
 
   //
@@ -270,7 +271,7 @@ int main(void) {
         tmp += A[i] + B[i];
       }
       S[0] += tmp;
-    }, VERIFY(0, 1, S[0], 5 * (N + (N/2*(N+1))) ));
+    }, {VERIFY(0, 1, S[0], 5 * (N + (N/2*(N+1))) ); any_fail += fail;});
   }
 
   //
@@ -303,7 +304,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], 6 + SUMS * (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], 6 + SUMS * (N/2*(N+1))); any_fail += fail;})
   }
 
   //
@@ -339,7 +340,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))); any_fail += fail;})
   }
 
   //
@@ -371,7 +372,7 @@ int main(void) {
       }
       S[0] += tmp;
     },
-    VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))); any_fail += fail;})
   }
 
   //
@@ -393,7 +394,7 @@ int main(void) {
     ,
     {
     },
-    VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))))
+    {VERIFY(0, 1, S[0], SUMS * (N/2*(N+1))); any_fail += fail;})
   }
 
   //
@@ -425,8 +426,8 @@ int main(void) {
         tmp += A[i];
       }
       S[0] = tmp;
-    }, VERIFY(0, 1, S[0], 3 * (33*33 + 66*33) ));
+    }, {VERIFY(0, 1, S[0], 3 * (33*33 + 66*33) ); any_fail += fail;});
   }
 
-  return 0;
+  return any_fail > 0;
 }

--- a/t-unified-parforsimd/test.c
+++ b/t-unified-parforsimd/test.c
@@ -36,11 +36,11 @@ int main()
       printf("%d: a %d != %d (error %d)\n", i, a[i], aa[i], ++error);
     if (error > 10) {
       printf("abort\n");
-      return 0;
+      return 1;
     }
   }
 
   // report
   printf("done with %d errors\n", error);
-  return error;
+  return error > 0;
 }

--- a/t-unified-reduction-struct/test.cpp
+++ b/t-unified-reduction-struct/test.cpp
@@ -81,6 +81,7 @@ N*5 \
 }
 
 int main(void) {
+  int any_fail = 0;
   check_offloading();
 
   struct DataTy Data;
@@ -111,9 +112,9 @@ int main(void) {
         {
           REDUCTION_FINAL();
         },
-        VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+        {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
     }
   }
 
-  return 0;
+  return any_fail > 0;
 }

--- a/t-unified-reduction-team/test.c
+++ b/t-unified-reduction-team/test.c
@@ -90,6 +90,7 @@ INIT1 + INIT2 + \
 }
 
 int main(void) {
+  int any_fail = 0;
   check_offloading();
 
   double Ad[N], Bd[N], Cd[N], Dd[N], Ed[N];
@@ -138,7 +139,7 @@ int main(void) {
       },
       {
         REDUCTION_FINAL();
-      }, VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+      }, {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
   }
 
   //
@@ -163,7 +164,7 @@ int main(void) {
       },
       {
         REDUCTION_FINAL();
-      }, VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+      }, {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
   }
 
   //
@@ -186,7 +187,7 @@ int main(void) {
       },
       {
         REDUCTION_FINAL();
-      }, VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+      }, {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
   }
 
   //
@@ -210,7 +211,7 @@ int main(void) {
       },
       {
         REDUCTION_FINAL();
-      }, VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+      }, {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
   }
 
   //
@@ -233,7 +234,7 @@ int main(void) {
     },
     {
       REDUCTION_FINAL();
-    }, VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+    }, {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
 
   //
   // Test: reduction on target teams distribute parallel for.
@@ -249,7 +250,7 @@ int main(void) {
         {
           REDUCTION_FINAL();
         },
-        VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+        {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
     }
   }
 
@@ -267,7 +268,7 @@ int main(void) {
         {
           REDUCTION_FINAL();
         },
-        VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+        {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
     }
   }
 
@@ -286,7 +287,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -305,7 +306,7 @@ int main(void) {
         {
           REDUCTION_FINAL();
         },
-        VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+        {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
     }
   }
 
@@ -324,7 +325,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -343,7 +344,7 @@ int main(void) {
         {
           REDUCTION_FINAL();
         },
-        VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+        {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
     }
   }
 
@@ -361,7 +362,7 @@ int main(void) {
         {
           REDUCTION_FINAL();
         },
-        VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+        {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
     }
   }
 
@@ -380,7 +381,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -400,7 +401,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -420,7 +421,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -440,7 +441,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -460,7 +461,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -480,7 +481,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -500,7 +501,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -520,7 +521,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -540,7 +541,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -562,7 +563,7 @@ int main(void) {
         {
           REDUCTION_FINAL();
         },
-        VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+        {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
     }
   }
 
@@ -583,7 +584,7 @@ int main(void) {
         {
           REDUCTION_FINAL();
         },
-        VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+        {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
     }
   }
 
@@ -605,7 +606,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -627,7 +628,7 @@ int main(void) {
         {
           REDUCTION_FINAL();
         },
-        VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+        {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
     }
   }
 
@@ -649,7 +650,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -671,7 +672,7 @@ int main(void) {
         {
           REDUCTION_FINAL();
         },
-        VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+        {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
     }
   }
 
@@ -692,7 +693,7 @@ int main(void) {
         {
           REDUCTION_FINAL();
         },
-        VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+        {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
     }
   }
 
@@ -714,7 +715,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -737,7 +738,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -760,7 +761,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -783,7 +784,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -806,7 +807,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -829,7 +830,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -852,7 +853,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -875,7 +876,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -898,7 +899,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -917,7 +918,7 @@ int main(void) {
         {
           REDUCTION_FINAL();
         },
-        VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+        {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
     }
   }
 
@@ -935,7 +936,7 @@ int main(void) {
         {
           REDUCTION_FINAL();
         },
-        VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+        {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
     }
   }
 
@@ -954,7 +955,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -973,7 +974,7 @@ int main(void) {
         {
           REDUCTION_FINAL();
         },
-        VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+        {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
     }
   }
 
@@ -992,7 +993,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -1011,7 +1012,7 @@ int main(void) {
         {
           REDUCTION_FINAL();
         },
-        VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+        {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
     }
   }
 
@@ -1029,7 +1030,7 @@ int main(void) {
         {
           REDUCTION_FINAL();
         },
-        VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+        {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
     }
   }
 
@@ -1048,7 +1049,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -1068,7 +1069,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -1088,7 +1089,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -1108,7 +1109,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -1128,7 +1129,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -1148,7 +1149,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -1168,7 +1169,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -1188,7 +1189,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -1208,7 +1209,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -1230,7 +1231,7 @@ int main(void) {
         {
           REDUCTION_FINAL();
         },
-        VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+        {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
     }
   }
 
@@ -1251,7 +1252,7 @@ int main(void) {
         {
           REDUCTION_FINAL();
         },
-        VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+        {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
     }
   }
 
@@ -1273,7 +1274,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -1295,7 +1296,7 @@ int main(void) {
         {
           REDUCTION_FINAL();
         },
-        VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+        {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
     }
   }
 
@@ -1317,7 +1318,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -1339,7 +1340,7 @@ int main(void) {
         {
           REDUCTION_FINAL();
         },
-        VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+        {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
     }
   }
 
@@ -1360,7 +1361,7 @@ int main(void) {
         {
           REDUCTION_FINAL();
         },
-        VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+        {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
     }
   }
 
@@ -1382,7 +1383,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -1405,7 +1406,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -1428,7 +1429,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -1451,7 +1452,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -1474,7 +1475,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -1497,7 +1498,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -1520,7 +1521,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -1543,7 +1544,7 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
@@ -1566,10 +1567,10 @@ int main(void) {
           {
             REDUCTION_FINAL();
           },
-          VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]));
+          {VERIFY(0, 1, OUT[i], (trial+1) * EXPECTED[i]); any_fail += fail;});
       }
     }
   }
 
-  return 0;
+  return any_fail > 0;
 }

--- a/t-unified-runtime-calls/test.c
+++ b/t-unified-runtime-calls/test.c
@@ -437,8 +437,6 @@ int main(void) {
     }
     }, {VERIFY(0, 1, A[i], omp_is_initial_device() ? A[1] - A[1] : 2.0); any_fail += fail;});
 
-  return 0;
-
 #if 0
   //
   // Test: omp_get_initial_device(). Unspecified behavior when

--- a/t-unified-simd/test.c
+++ b/t-unified-simd/test.c
@@ -36,11 +36,11 @@ int main()
       printf("%d: a %d != %d (error %d)\n", i, a[i], aa[i], ++error);
     if (error > 10) {
       printf("abort\n");
-      return 0;
+      return 1;
     }
   }
 
   // report
   printf("done with %d errors\n", error);
-  return error;
+  return error > 0;
 }

--- a/t-unified-single/test.c
+++ b/t-unified-single/test.c
@@ -16,6 +16,7 @@
 #define ZERO(X) ZERO_ARRAY(N, X) 
 
 int main(void) {
+  int any_fail = 0;
   check_offloading();
 
   double A[N], B[N], C[N], D[N], E[N];
@@ -49,7 +50,7 @@ int main(void) {
           B[i] += A[i];
         }
       }
-    }, VERIFY(0, N, B[i], 3*i+2));
+    }, {VERIFY(0, N, B[i], 3*i+2); any_fail += fail;});
   }
 
   //
@@ -79,7 +80,7 @@ int main(void) {
           B[i] += A[i];
         }
       }
-    }, VERIFY(0, N, B[i], 2*i+1));
+    }, {VERIFY(0, N, B[i], 2*i+1); any_fail += fail;});
   }
 
   //
@@ -110,7 +111,7 @@ int main(void) {
           B[i] += A[i];
         }
       }
-    }, VERIFY(0, N, B[i], 3*i+3));
+    }, {VERIFY(0, N, B[i], 3*i+3); any_fail += fail;});
   }
 
 #if 0
@@ -142,9 +143,9 @@ int main(void) {
       for (int i = 0; i < N; i++) {
         B[i] += A[i];
       }
-    }, VERIFY(0, N, B[i], 4*i+3));
+    }, {VERIFY(0, N, B[i], 4*i+3); any_fail += fail;});
   }
 #endif
 
-  return 0;
+  return any_fail > 0;
 }

--- a/t-unified-target-basic/test.c
+++ b/t-unified-target-basic/test.c
@@ -12,6 +12,7 @@
 #define INIT() INIT_LOOP(N, {C[i] = 1; D[i] = i; E[i] = -i;})
 
 int main(void){
+  int any_fail = 0;
   check_offloading();
 
   int fail;
@@ -37,6 +38,7 @@ int main(void){
   } else {
     printf ("Test1: Succeeded\n");
   }
+  any_fail += fail;
 #endif
 
   //
@@ -59,6 +61,7 @@ int main(void){
   } else {
     printf ("Test2: Succeeded\n");
   }
+  any_fail += fail;
 
   //
   // Test: Printf on device
@@ -79,5 +82,5 @@ int main(void){
     printf ("Parallel %d:%f\n", TT[1], D[1]);
   }
 
-  return 0;
+  return any_fail > 0;
 }

--- a/t-unified-target-map-ptr/test.cpp
+++ b/t-unified-target-map-ptr/test.cpp
@@ -34,6 +34,7 @@ typedef struct S {
 } S;
 
 int main(void){
+  int any_fail = 0;
   #if CHECK
     check_offloading();
   #endif
@@ -75,6 +76,7 @@ int main(void){
   } else {
     printf ("Test full extent: Succeeded\n");
   }
+  any_fail += fail;
 #endif
 
 #if FULL_ZERO
@@ -101,6 +103,7 @@ int main(void){
   } else {
     printf ("Test full extent with zero length ptrs: Succeeded\n");
   }
+  any_fail += fail;
 #endif
 
   #if FULL_ZERO_NULL
@@ -143,6 +146,7 @@ int main(void){
   } else {
     printf ("Test full extent with zero length ptrs and NULL ptr: Succeeded\n");
   }
+  any_fail += fail;
 #endif
 
 #if FULL_ZERO_IMPLICIT
@@ -168,6 +172,7 @@ int main(void){
   } else {
     printf ("Test full extent with implicit zero length ptrs: Succeeded\n");
   }
+  any_fail += fail;
 #endif
 
 #if FULL_S
@@ -191,6 +196,7 @@ int main(void){
   } else {
     printf ("Test full extent struct: Succeeded\n");
   }
+  any_fail += fail;
 #endif
 
 #if OFFSET
@@ -216,6 +222,7 @@ int main(void){
   } else {
     printf ("Test Offset: Succeeded\n");
   }
+  any_fail += fail;
 
   // Restore original pointers
   pA = &A[0];
@@ -246,6 +253,7 @@ int main(void){
   } else {
     printf ("Test Offset struct: Succeeded\n");
   }
+  any_fail += fail;
 #endif
 
 #if FP
@@ -268,6 +276,7 @@ int main(void){
   } else {
     printf ("Test first-private: Succeeded\n");
   }
+  any_fail += fail;
 #endif
 
 #if FP_RANGES
@@ -289,6 +298,7 @@ int main(void){
   } else {
     printf ("Test first-private with ranges: Succeeded\n");
   }
+  any_fail += fail;
 #endif
 
 #if FPPTR
@@ -310,6 +320,7 @@ int main(void){
   } else {
     printf ("Test first-private with pointers: Succeeded\n");
   }
+  any_fail += fail;
 #endif
 
 #if DEVICEPTR
@@ -343,6 +354,7 @@ int main(void){
   } else {
     printf ("Test device_ptr: Succeeded\n");
   }
+  any_fail += fail;
 #endif
 
 #if PTR_REF
@@ -371,7 +383,8 @@ int main(void){
   } else {
     printf ("Test refs to ptrs: Succeeded\n");
   }
+  any_fail += fail;
 #endif
 
-  return 0;
+  return any_fail > 0;
 }

--- a/t-unified-target-teams-distribute-simd/test.c
+++ b/t-unified-target-teams-distribute-simd/test.c
@@ -50,7 +50,9 @@ int check_results_priv(double *A, double *B){
   } \
   success += check_results(A); \
   if (success == expected) \
-    printf("Succeeded\n");
+    printf("Succeeded\n"); \
+  else \
+    any_fail += 1;
 
 #define CODE_PRIV() \
   ZERO(A); \
@@ -69,12 +71,15 @@ int check_results_priv(double *A, double *B){
   } \
   success += check_results_priv(A, B); \
   if (success == expected) \
-    printf("Succeeded\n");
+    printf("Succeeded\n"); \
+  else \
+    any_fail += 1;
 
 int main(void) {
   check_offloading();
 
   double A[N], B[N], C[N], D[N], E[N];
+  int any_fail = 0;
   int fail = 0;
   int expected = 1;
   int success = 0;
@@ -201,6 +206,7 @@ int main(void) {
   }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 #endif
 
   //
@@ -222,6 +228,7 @@ int main(void) {
 
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 #endif
 
   // // ***************************
@@ -255,6 +262,7 @@ int main(void) {
 
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: blocking loop where upper bound is not a multiple of tl*nte
@@ -285,6 +293,7 @@ int main(void) {
 
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   // **************************
   // Series 5: collapse
@@ -322,6 +331,7 @@ int main(void) {
       }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: 3 loops
@@ -357,7 +367,8 @@ int main(void) {
         }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
-  return 0;
+  return any_fail > 0;
 }
 

--- a/t-unified-target-teams-distribute/test.c
+++ b/t-unified-target-teams-distribute/test.c
@@ -16,6 +16,7 @@
 #define ZERO(X) ZERO_ARRAY(N, X)
 
 int main(void) {
+  int any_fail = 0;
   check_offloading();
 
   double A[N], B[N], C[N], D[N], E[N];
@@ -45,6 +46,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: #iterations > #teams
@@ -83,6 +85,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   // ****************************
   // Series 2: with dist_schedule
@@ -106,6 +109,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: #iterations == #teams, dist_schedule(#iterations)
@@ -125,6 +129,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: #iterations == #teams, dist_schedule(#iterations/10), variable chunk size
@@ -146,6 +151,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: #iterations > #teams, dist_schedule(1)
@@ -165,6 +171,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: #iterations > #teams, dist_schedule(#iterations)
@@ -184,6 +191,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: #iterations > #teams, dist_schedule(#iterations/10), variable chunk size
@@ -205,6 +213,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: #iterations < #teams, dist_schedule(1)
@@ -224,6 +233,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: #iterations < #teams, dist_schedule(#iterations)
@@ -243,6 +253,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: #iterations < #teams, dist_schedule(#iterations)
@@ -264,6 +275,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   // ****************************
   // Series 3: with ds attributes
@@ -294,6 +306,7 @@ int main(void) {
   }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: firstprivate
@@ -332,6 +345,7 @@ int main(void) {
   }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: lastprivate
@@ -349,6 +363,7 @@ int main(void) {
 
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   // ***************************
   // Series 4: with parallel for
@@ -380,6 +395,7 @@ int main(void) {
 
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: blocking loop where upper bound is not a multiple of tl*nte
@@ -408,6 +424,7 @@ int main(void) {
 
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   // **************************
   // Series 5: collapse
@@ -441,6 +458,7 @@ int main(void) {
     }
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
+  any_fail += fail;
 
   //
   // Test: 3 loops
@@ -472,5 +490,7 @@ int main(void) {
 	}
   if(fail) printf("Failed\n");
   else printf("Succeeded\n");
-  return 0;
+  any_fail += fail;
+
+  return any_fail > 0;
 }

--- a/t-unified-target-update/test.c
+++ b/t-unified-target-update/test.c
@@ -22,7 +22,7 @@ int main(void){
 #if CHECK
     check_offloading();
 #endif
-
+  int any_fail = 0;
   int fail;
   double A[N], B[N], C[N], D[N], E[N];
   double *pA, *pB, *pC, *pD, *pE;
@@ -55,6 +55,7 @@ int main(void){
     } else {
       printf ("Test update from: Succeeded\n");
     }
+    any_fail += fail;
 
     // Now modify host arrays C and D
     for(int i = 0; i < N; i++){
@@ -81,6 +82,7 @@ int main(void){
     } else {
       printf ("Test update to: Succeeded\n");
     }
+    any_fail += fail;
   }
 #endif
 
@@ -105,6 +107,7 @@ int main(void){
     } else {
       printf ("Test update from with zero-length ptrs: Succeeded\n");
     }
+    any_fail += fail;
 
     // Now modify host arrays C and D
     for(int i = 0; i < N; i++){
@@ -131,6 +134,7 @@ int main(void){
     } else {
       printf ("Test update to with zero-length ptrs: Succeeded\n");
     }
+    any_fail += fail;
   }
 #endif
 
@@ -160,6 +164,7 @@ int main(void){
     } else {
       printf ("Test update from with offsets: Succeeded\n");
     }
+    any_fail += fail;
 
     // Now modify host arrays C and D
     for(int i = 0; i < N; i++){
@@ -187,8 +192,9 @@ int main(void){
     } else {
       printf ("Test update to with offsets: Succeeded\n");
     }
+    any_fail += fail;
   }
 #endif
 
-  return 0;
+  return any_fail > 0;
 }

--- a/t-unified-task/task.c
+++ b/t-unified-task/task.c
@@ -32,6 +32,7 @@
 
 int main ()
 {
+  int any_errors = 0;
   int a[N], aa[N];
   int b[N], bb[N];
   int c[N], cc[N];
@@ -81,6 +82,7 @@ int main ()
     if (b[i] != bb[i]) printf("%4i: got b %d, expected %d, error %d\n", i, b[i], bb[i], ++errors);
   }
   printf("#1 got %d errors\n", errors);
+  any_errors += errors;
 #endif
 
   // Test: task within parallel
@@ -125,6 +127,7 @@ int main ()
     if (b[i] != bb[i]) printf("%4i: got b %d, expected %d, error %d\n", i, b[i], bb[i], ++errors);
   }
   printf("#2 got %d errors\n", errors);
+  any_errors += errors;
 #endif
 
   // Test: multiple nested tasks in parallel region
@@ -179,6 +182,7 @@ int main ()
     if (b[i] != bb[i]) printf("%4i: got b %d, expected %d, error %d\n", i, b[i], bb[i], ++errors);
   }
   printf("#3 got %d errors\n", errors);
+  any_errors += errors;
 #endif
 
   // Test: three successive tasks in a parallel region
@@ -230,6 +234,7 @@ int main ()
     if (b[i] != bb[i]) printf("%4i: got b %d, expected %d, error %d\n", i, b[i], bb[i], ++errors);
   }
   printf("#4 got %d errors\n", errors);
+  any_errors += errors;
 #endif
 
   // Test: change of context when entering/exiting tasks
@@ -312,6 +317,7 @@ int main ()
   }
 
   printf("#5 got %d errors\n", errors);
+  any_errors += errors;
 #endif
 
   // Test: change of context when using if clause
@@ -394,6 +400,7 @@ int main ()
   }
 
   printf("#6 got %d errors\n", errors);
+  any_errors += errors;
 #endif
 
   // Test: final
@@ -448,6 +455,7 @@ int main ()
     if (b[i] != bb[i]) printf("%4i: got b %d, expected %d, error %d\n", i, b[i], bb[i], ++errors);
   }
   printf("#7 got %d errors\n", errors);
+  any_errors += errors;
 #endif
 
   // Test: untied
@@ -502,6 +510,7 @@ int main ()
     if (b[i] != bb[i]) printf("%4i: got b %d, expected %d, error %d\n", i, b[i], bb[i], ++errors);
   }
   printf("#8 got %d errors\n", errors);
+  any_errors += errors;
 #endif
 
   // Test: mergeaeble
@@ -556,6 +565,7 @@ int main ()
     if (b[i] != bb[i]) printf("%4i: got b %d, expected %d, error %d\n", i, b[i], bb[i], ++errors);
   }
   printf("#9 got %d errors\n", errors);
+  any_errors += errors;
 #endif
 
   // Test: private
@@ -608,6 +618,7 @@ int main ()
     if (b[i] != bb[i]) printf("%4i: got b %d, expected %d, error %d\n", i, b[i], bb[i], ++errors);
   }
   printf("#10 got %d errors\n", errors);
+  any_errors += errors;
 #endif
 
   // Test: depend
@@ -657,6 +668,7 @@ int main ()
     if (b[i] != bb[i]) printf("%4i: got b %d, expected %d, error %d\n", i, b[i], bb[i], ++errors);
   }
   printf("#11 got %d errors\n", errors);
+  any_errors += errors;
 #endif
 
   // Test: inverted priority
@@ -708,7 +720,8 @@ int main ()
     if (b[i] != bb[i]) printf("%4i: got b %d, expected %d, error %d\n", i, b[i], bb[i], ++errors);
   }
   printf("#12 got %d errors\n", errors);
+  any_errors += errors;
 #endif
 
-  return 0;
+  return any_errors > 0;
 }

--- a/t-unified-ttdpf-nested-parallel/test.c
+++ b/t-unified-ttdpf-nested-parallel/test.c
@@ -21,6 +21,7 @@ double S[M];
 double p[2];
 
 int main(void) {
+  int any_fail = 0;
   check_offloading();
 
   INIT();
@@ -58,7 +59,7 @@ int main(void) {
     }
     S[idx] += tmp;
   },
-  VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))))
+  {VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))); any_fail += 1;})
   #undef NESTED_PARALLEL_FOR_CLAUSES
   #define NESTED_PARALLEL_FOR_CLAUSES proc_bind(close)
   #include "defines.h"
@@ -78,7 +79,7 @@ int main(void) {
     }
     S[idx] += tmp;
   },
-  VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))))
+  {VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))); any_fail += 1;})
 
   #undef NESTED_PARALLEL_FOR_CLAUSES
   #define NESTED_PARALLEL_FOR_CLAUSES proc_bind(spread)
@@ -99,7 +100,7 @@ int main(void) {
     }
     S[idx] += tmp;
   },
-  VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))))
+  {VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))); any_fail += 1;})
 
   //
   // Test: private, shared clauses on omp target teams distribute parallel for with nested parallel.
@@ -128,7 +129,7 @@ int main(void) {
     }
     S[idx] += tmp;
   },
-  VERIFY(0, tms*th, S[i], (double) 6 + SUMS * (N/2*(N+1))))
+  {VERIFY(0, tms*th, S[i], (double) 6 + SUMS * (N/2*(N+1))); any_fail += 1;})
 
   //
   // Test: firstprivate clause on omp target teams distribute parallel for with nested parallel.
@@ -159,7 +160,7 @@ int main(void) {
     }
     S[idx] += tmp;
   },
-  VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))))
+  {VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))); any_fail += 1;})
 
   //
   // Test: lastprivate clause on omp target teams distribute parallel for with nested parallel.
@@ -200,7 +201,7 @@ int main(void) {
     }
     S[idx] += tmp;
   }
-  , VERIFY(0, tms*th, S[i], (double) 2 * (N + (N/2*(N+1))) ));
+  , {VERIFY(0, tms*th, S[i], (double) 2 * (N + (N/2*(N+1))) ); any_fail += 1;});
 
   //
   // Test: private clause on omp target teams distribute parallel for with nested parallel.
@@ -230,7 +231,7 @@ int main(void) {
     }
     S[idx] += tmp;
   },
-  VERIFY(0, tms*th, S[i], (double) 6 + SUMS * (N/2*(N+1))))
+  {VERIFY(0, tms*th, S[i], (double) 6 + SUMS * (N/2*(N+1))); any_fail += 1;})
 
   //
   // Test: firstprivate clause on omp target teams distribute parallel for with nested parallel.
@@ -262,7 +263,7 @@ int main(void) {
     }
     S[idx] += tmp;
   },
-  VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))))
+  {VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))); any_fail += 1;})
 
   //
   // Test: collapse clause on omp target teams distribute parallel for with nested parallel.
@@ -290,7 +291,7 @@ int main(void) {
     }
     S[idx] += tmp;
   },
-  VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))))
+  {VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))); any_fail += 1;})
 
   //
   // Test: ordered clause on omp target teams distribute parallel for with nested parallel.
@@ -308,7 +309,7 @@ int main(void) {
   ,
   {
   },
-  VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))))
+  {VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))); any_fail += 1;})
 
   //
   // Test: Ensure coalesced scheduling on GPU.
@@ -338,11 +339,11 @@ int main(void) {
         }
         S[idx] = tmp;
       }
-    , VERIFY(0, tms*th, S[i], (double) 3 * 95 * 48 ));
+    , {VERIFY(0, tms*th, S[i], (double) 3 * 95 * 48 ); any_fail += 1;});
   } else {
     DUMP_SUCCESS(1);
   }
   //DUMP_SUCCESS(1);
 
-  return 0;
+  return any_fail > 0;
 }

--- a/t-unified-ttdpfs-nested-parallel/test.c
+++ b/t-unified-ttdpfs-nested-parallel/test.c
@@ -21,6 +21,7 @@ double S[M];
 double p[2];
 
 int main(void) {
+  int any_fail = 0;
   check_offloading();
 
   INIT();
@@ -52,7 +53,7 @@ int main(void) {
     }
     S[idx] += tmp;
   },
-  VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))))
+  {VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))); any_fail += 1;})
 
   #undef NESTED_PARALLEL_FOR_CLAUSES
   #define NESTED_PARALLEL_FOR_CLAUSES proc_bind(close)
@@ -73,7 +74,7 @@ int main(void) {
     }
     S[idx] += tmp;
   },
-  VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))))
+  {VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))); any_fail += 1;})
 
   #undef NESTED_PARALLEL_FOR_CLAUSES
   #define NESTED_PARALLEL_FOR_CLAUSES proc_bind(spread)
@@ -94,7 +95,7 @@ int main(void) {
     }
     S[idx] += tmp;
   },
-  VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))))
+  {VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))); any_fail += 1;})
 
   //
   // Test: private, shared clauses on omp target teams distribute parallel for with nested parallel.
@@ -123,7 +124,7 @@ int main(void) {
     }
     S[idx] += tmp;
   },
-  VERIFY(0, tms*th, S[i], (double) 6 + SUMS * (N/2*(N+1))))
+  {VERIFY(0, tms*th, S[i], (double) 6 + SUMS * (N/2*(N+1))); any_fail += 1;})
 
   //
   // Test: firstprivate clause on omp target teams distribute parallel for with nested parallel.
@@ -154,7 +155,7 @@ int main(void) {
     }
     S[idx] += tmp;
   },
-  VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))))
+  {VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))); any_fail += 1;})
 
   //
   // Test: lastprivate clause on omp target teams distribute parallel for with nested parallel.
@@ -195,7 +196,7 @@ int main(void) {
     }
     S[idx] += tmp;
   }
-  , VERIFY(0, tms*th, S[i], (double) 2 * (N + (N/2*(N+1))) ));
+  , {VERIFY(0, tms*th, S[i], (double) 2 * (N + (N/2*(N+1))) ); any_fail += 1;});
 
   //
   // Test: private clause on omp target teams distribute parallel for with nested parallel.
@@ -225,7 +226,7 @@ int main(void) {
     }
     S[idx] += tmp;
   },
-  VERIFY(0, tms*th, S[i], (double) 6 + SUMS * (N/2*(N+1))))
+  {VERIFY(0, tms*th, S[i], (double) 6 + SUMS * (N/2*(N+1))); any_fail += 1;})
 
   //
   // Test: firstprivate clause on omp target teams distribute parallel for with nested parallel.
@@ -257,7 +258,7 @@ int main(void) {
     }
     S[idx] += tmp;
   },
-  VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))))
+  {VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))); any_fail += 1;})
 
   //
   // Test: collapse clause on omp target teams distribute parallel for with nested parallel.
@@ -285,7 +286,7 @@ int main(void) {
     }
     S[idx] += tmp;
   },
-  VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))))
+  {VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))); any_fail += 1;})
 
   //
   // Test: ordered clause on omp target teams distribute parallel for with nested parallel.
@@ -303,7 +304,7 @@ int main(void) {
   ,
   {
   },
-  VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))))
+  {VERIFY(0, tms*th, S[i], (double) SUMS * (N/2*(N+1))); any_fail += 1;})
 
-  return 0;
+  return any_fail > 0;
 }

--- a/t-use-is-device-ptr/test.c
+++ b/t-use-is-device-ptr/test.c
@@ -13,6 +13,7 @@
 #define ZERO(X) ZERO_ARRAY(N, X) 
 
 int main(void) {
+  int any_error = 0;
   check_offloading();
 
   double A[N], B[N], C[N], D[N], E[N];
@@ -66,7 +67,8 @@ int main(void) {
       printf("Failed with %d errors\n", error);
     else
       printf("Success\n");
+    any_error += error;
   }
 
-  return 0;
+  return any_error > 0;
 }

--- a/xt-conditional-lastprivate/test.c
+++ b/xt-conditional-lastprivate/test.c
@@ -14,6 +14,7 @@
 #define ZERO(X) ZERO_ARRAY(N, X)
 
 int main(void) {
+  int any_fail = 0;
   check_offloading();
 
   int A[N], B[N], C[N], D[N], E[N];
@@ -104,8 +105,8 @@ int main(void) {
       double tmp = q0 + q1 + q2 + q3 + q4 + \
                    q5 + q6 + q7 + q8 + q9;
       S[0] = tmp;
-    }, VERIFY(0, 1, S[0], 30710 ));
+    }, {VERIFY(0, 1, S[0], 30710 ); any_fail += fail;});
   }
 
-  return 0;
+  return any_fail > 0;
 }

--- a/xt-debugflag/test.c
+++ b/xt-debugflag/test.c
@@ -14,6 +14,6 @@ int main()
     printf("### Success ### \n");
   else
     printf("### Error ###\n"); 
-  return 0;
+  return !Success;
 }
 

--- a/xt-nums-in-teams-par-for-default/test.cpp
+++ b/xt-nums-in-teams-par-for-default/test.cpp
@@ -114,5 +114,5 @@ int  main()
   printf("  completed\n");
 
   printf("tests completed with %d errors\n", error);
-  return 0;
+  return error > 0;
 }

--- a/xt-nums-in-teams-par-for-export/test.cpp
+++ b/xt-nums-in-teams-par-for-export/test.cpp
@@ -112,5 +112,5 @@ int  main()
   printf("  completed\n");
 
   printf("tests completed with %d errors\n", error);
-  return 0;
+  return error > 0;
 }

--- a/xt-target-dep-host-device/test.c
+++ b/xt-target-dep-host-device/test.c
@@ -15,5 +15,5 @@ int main(int argc, char *argv[]) {
   }
   if (b==3) printf("success\n");
   else printf("horrible failure\n");
-  return EXIT_SUCCESS;
+  return b != 3;
 }

--- a/xt-td-pf/test.cpp
+++ b/xt-td-pf/test.cpp
@@ -55,9 +55,12 @@ int check_results(int t, int n, double* a_h, double* a, double* b, double* c){
     success += check_results(t, n, a_h, a, b, c); \
   } \
   if (success == expected) \
-    printf("Succeeded\n");
+    printf("Succeeded\n"); \
+  else \
+    fail = 1;
 
 int main(int argc, char *argv[]) {
+  int fail = 0;
   double * a = (double *) malloc(MAX_N * sizeof(double));
   double * a_h = (double *) malloc(MAX_N * sizeof(double));
   double * b = (double *) malloc(MAX_N * sizeof(double));
@@ -197,5 +200,5 @@ int main(int argc, char *argv[]) {
 
   #pragma omp target exit data map(release:a[:MAX_N],b[:MAX_N],c[:MAX_N])
 
-  return 0;
+  return fail;
 }


### PR DESCRIPTION
Note: xt-declare-target-ctors has no in-program fail check and, hence, always returns 0. A couple always return 1 for the first error and some tests whether it runs without error checks.

For t-runtime-calls + t-unified-runtime-calls, the existing exit code handling did not trigger as before the last two tests (one commented out) was a spurious 'return 0'; the not-comment out test actually succeeded for me. For t-unified-for, handle a previously missed fail.

@doru1004 – please review. This should be the last simple exit-status non-zero on fail change.