### PR TITLE
Fix t-taskwait

### DIFF
--- a/t-taskwait/test.c
+++ b/t-taskwait/test.c
@@ -6,7 +6,10 @@
 #define PRINT(_args...)
 //#define PRINT(_args...) printf(_args)
 
+//#define SHOW_WARNING
+
 #define N 64
+#define N_MIN_EXPECTED 8 // Less is permitted but, e.g., 1 is pointless for this test
 
 #define TRY_TASK 1
 #define TASK_COMPUTE 1
@@ -15,11 +18,13 @@ int main ()
 {
   int a[N], aa[N];
   int b[N], bb[N];
-  int c[N], cc[N];
-  int d[N], dd[N];
-  int e[N], ee[N];
   int i, errors;
-  int cond = 0;
+  int num_threads = -1;
+
+  if (N < N_MIN_EXPECTED || N != 64) {
+    printf("inconsistent settings used\n");
+    return 1;
+  }
 
   check_offloading();
 
@@ -30,28 +35,30 @@ int main ()
   }
 
   // target starts 1 team and many threads in it
-  #pragma omp target map(tofrom: a, b)
+  #pragma omp target map(tofrom: a, b, num_threads)
   {
     #pragma omp parallel num_threads(64)
     {
       int id = omp_get_thread_num();
+      if (id == 0)
+        num_threads = omp_get_num_threads();
       a[id]++;
       #pragma omp task firstprivate(id) shared(b)
       {
-        PRINT("hi alex from  %d\n", id);
         int id = omp_get_thread_num();
+        PRINT("hi alex 1 from  %d\n", id);
         b[id]++;
 
         #pragma omp task firstprivate(id) shared(b)
         {
-          PRINT("hi alex from  %d\n", id);
           int id = omp_get_thread_num();
+          PRINT("hi alex 2 from  %d\n", id);
           b[id]++;
 
           #pragma omp task firstprivate(id) shared(b)
           {
-            PRINT("hi alex from  %d\n", id);
             int id = omp_get_thread_num();
+            PRINT("hi alex 3 from  %d\n", id);
             b[id]++;
           }
 	  // wait for child to finish
@@ -63,19 +70,48 @@ int main ()
     }
   }
 
-  // reproduce
-  for(i=0; i<N; i++) {
-    aa[i]++;
-    bb[i]+=3;
-  }
-
   // verify
   errors = 0;
-  for(i=0; i<N; i++) {
-    if (a[i] != aa[i]) printf("%4i: got a %d, expected %d, error %d\n", i, a[i], aa[i], ++errors);
-    if (b[i] != bb[i]) printf("%4i: got b %d, expected %d, error %d\n", i, b[i], bb[i], ++errors);
+  if (num_threads < N_MIN_EXPECTED || num_threads > N) {
+    printf("got a %d threads, OpenMP requires 1 to %d, program expects at least %d\n", num_threads, N, N_MIN_EXPECTED);
+    ++errors;
+  }
+
+
+  int b_expected = 0;
+  int b_result = 0;
+  int warnings = 0;
+  int thread_used = 0;
+
+  for(i=0; i < num_threads; i++) {
+    if (a[i] != aa[i] + 1) printf("%4i: got a %d, expected %d, error %d\n", i, a[i], aa[i] + 1, ++errors);
+#if SHOW_WARNING
+    // Expect that each thread at least executed one task - and not more than 10 tasks
+    // Perfectly balanced would be 3 tasks but scheduling might cause slightly different results.
+    // It turns out that even 0 is very common with multiple compilers (nearly always), rendering this check
+    // pointless, unfortunately.
+    if (b[i] < bb[i] + 1 || b[i] > bb[i] + 10)
+      printf("WARNING: %4i: got b %d, expected between %d and %d, error %d\n", i, b[i], bb[i] + 1, bb[i] + 10, ++warnings);
+#endif
+    if (b[i] < bb[i] || b[i] > bb[i] + num_threads * 3)
+      printf("%4i: got b %d, expected %d + cnt, but value is completely bogus, error %d\n", i, b[i], bb[i], ++errors);
+    if (b[i] + 2 >= bb[i]) // executed at least two of the three tasks
+      thread_used++;
+    b_result += b[i];
+    b_expected += bb[i] + 3;
+  }
+  if (b_expected != b_result) {
+    printf("total result for b is wrong, got %d, expected %d\n", b_result, b_expected);
+    errors++;
+  }
+  // Expect at least somewhat balanced thread use: 2 of 3 tasks processed by at least half of the threads.
+  if (thread_used < num_threads/2 + num_threads % 2) {
+    printf("Only %d threads of %d threads actually processed the tasks\n", thread_used, num_threads);
+    errors++;
   }
   printf("got %d errors\n", errors);
+  if (warnings)
+   printf("got %d warnings\n", warnings);
 
   return errors > 0;
 }


### PR DESCRIPTION
The testcase has two issues:

* It assumes that num_threads(64) can always be fulfilled, which depending on how teams/thread/simd vectors are mapped to GPU device hardware is not always the case. (Some compilers have different run modes, some favoring SIMD vectorization, some parallelization.)

* It assumes perfectly balanced execution where each thread executes exactly 3 tasks. But scheduling does not work like this. Testing with 64 threads, there is are surprisingly many threads executing zero tasks.

The code has been reworked to handle less than 64 threads; it strictly requires 8 to be somewhat reasonable (and outputs an error if not fulfilled), but it handles any number (<= 64) using the actual num_threads.

Additionally, it checks now only that the final result makes sense, albeit to have some balance, it checks that at least half of the threads execute at least two tasks.

@doru1004 – please review.

***

The second issue shows up nearly every time with both GCC and Clang – with 64 threads, even a check for >= 1 and <= 10 tasks per thread triggers almost every time!

The first issue shows with the current teams/thread(parallel)/simd(vector) implementation of GCC – which permits only 16 threads (= 16 wavefronts); the optional alternative mode using only teams + threads/parallel (+ SIMT) permits more.